### PR TITLE
Fixing some reported issues

### DIFF
--- a/R/attributesCharts.R
+++ b/R/attributesCharts.R
@@ -17,6 +17,7 @@
 
 #' @export
 attributesCharts <- function(jaspResults, dataset, options) {
+
   # reading variables in from the GUI
   total <- options$total
   D <- options[["defectiveOrDefect"]]

--- a/R/msaAttribute.R
+++ b/R/msaAttribute.R
@@ -301,10 +301,8 @@ msaAttribute <- function(jaspResults, dataset, options, ...) {
       }
 
       for (measurement in measurements) {
-        # if (is.numeric(dataset[[measurement]])) {
         dataset[measurement] <- as.character(dataset[[measurement]])
         dataset[standards] <- as.character(dataset[[standards]])
-        # }
       }
 
       matchesWithin <- vector(mode = "numeric")
@@ -482,9 +480,7 @@ msaAttribute <- function(jaspResults, dataset, options, ...) {
       numberInspected <- length(unique(dataset[[parts]]))
 
       for (measurement in measurements) {
-        # if (is.numeric(dataset[[measurement]])) {
           dataset[measurement] <- as.character(dataset[[measurement]])
-        # }
       }
 
       matchesWithin <- vector(mode = "numeric")

--- a/R/msaAttribute.R
+++ b/R/msaAttribute.R
@@ -51,7 +51,7 @@ msaAttribute <- function(jaspResults, dataset, options, ...) {
              all.target = c(measurements, standards, operators, parts),
              exitAnalysisIfErrors = TRUE)
 
-  if (!wideFormat && ready){
+  if (!wideFormat && ready) {
     dataset <- dataset[order(dataset[[operators]]),]
     dataset <- dataset[order(dataset[[parts]]),]
     nrep <- table(dataset[operators])[[1]]/length(unique(dataset[[parts]]))
@@ -91,7 +91,8 @@ msaAttribute <- function(jaspResults, dataset, options, ...) {
       jaspResults[["AAAtableGraphs"]] <- createJaspContainer(gettext("Attributes Agreement Analysis"))
       jaspResults[["AAAtableGraphs"]]$position <- 16
     }
-    jaspResults[["AAAtableGraphs"]] <- .aaaTableGraphs(ready = ready, dataset = dataset, measurements = measurements, parts = parts, operators = operators, options =  options, standards = standards)
+    jaspResults[["AAAtableGraphs"]] <- .aaaTableGraphs(ready = ready, dataset = dataset, measurements = measurements,
+                                                       parts = parts, operators = operators, options =  options, standards = standards)
   }else{
     if (is.null(jaspResults[["AAAtableGraphs"]])) {
       jaspResults[["AAAtableGraphs"]] <- createJaspContainer(gettext("Attributes Agreement Analysis"))
@@ -300,10 +301,10 @@ msaAttribute <- function(jaspResults, dataset, options, ...) {
       }
 
       for (measurement in measurements) {
-        if (is.numeric(dataset[[measurement]])) {
-          dataset[measurement] <- as.character(dataset[[measurement]])
-          dataset[standards] <- as.character(dataset[[standards]])
-        }
+        # if (is.numeric(dataset[[measurement]])) {
+        dataset[measurement] <- as.character(dataset[[measurement]])
+        dataset[standards] <- as.character(dataset[[standards]])
+        # }
       }
 
       matchesWithin <- vector(mode = "numeric")
@@ -481,9 +482,9 @@ msaAttribute <- function(jaspResults, dataset, options, ...) {
       numberInspected <- length(unique(dataset[[parts]]))
 
       for (measurement in measurements) {
-        if (is.numeric(dataset[[measurement]])) {
+        # if (is.numeric(dataset[[measurement]])) {
           dataset[measurement] <- as.character(dataset[[measurement]])
-        }
+        # }
       }
 
       matchesWithin <- vector(mode = "numeric")

--- a/R/msaGaugeLinearity.R
+++ b/R/msaGaugeLinearity.R
@@ -97,7 +97,7 @@ msaGaugeLinearity <- function(jaspResults, dataset, options, ...) {
       singleMeasurementParts <- paste(names(which(table(dataset[[parts]]) < 2)), collapse = ", ")
       table2$setError(gettextf("T-Test requires more than 1 measurement per part. Less than 2 valid measurement(s) detected in Part(s) %s.", singleMeasurementParts))
       return(table2)
-    } 
+    }
     variancePerPart <- tapply(dataset[[measurements]], dataset[[parts]], var)
     if(any(variancePerPart == 0)) {
       noVarParts <- paste(names(which(variancePerPart == 0)), collapse = ", ")
@@ -107,7 +107,7 @@ msaGaugeLinearity <- function(jaspResults, dataset, options, ...) {
       singleMeasurementParts <- paste(names(which(table(dataset[[parts]]) < 2)), collapse = ", ")
       table2$setError(gettextf("T-Test requires more than 1 measurement per part. Less than 2 valid measurement(s) detected in Part(s) %s.", singleMeasurementParts))
       return(table2)
-    } 
+    }
     variancePerPart <- tapply(dataset[[measurements]], dataset[[parts]], var)
     if(any(variancePerPart == 0)) {
       noVarParts <- paste(names(which(variancePerPart == 0)), collapse = ", ")
@@ -160,11 +160,11 @@ msaGaugeLinearity <- function(jaspResults, dataset, options, ...) {
       jaspGraphs::geom_point(data = df, mapping = ggplot2::aes(x = Ref, y = Bias), fill = "red",size = 4) +
       ggplot2::scale_y_continuous(limits = c(min(df2$Bias), max(df2$Bias) * 2)) +
       ggplot2::annotate("text", x = mean(df2$Ref), y = max(df2$Bias)*1.25, size = 5.5,
-                        label = sprintf("y = %.2f %s %.2fx", coefficientConstant, plusOrMin, abs(coefficientSlope)))
+                        label = sprintf("y = %.2f %s %.2fx", coefficientConstant, plusOrMin, abs(coefficientSlope))) +
+      jaspGraphs::geom_rangeframe() +
+      jaspGraphs::themeJaspRaw()
 
-
-    p1 <- jaspGraphs::themeJasp(p1)
-    plot1$plotObject <- jaspGraphs::themeJasp(p1)
+    plot1$plotObject <- p1
 
     table2$setData(list("predictor" = c("Intercept", "Slope"),
                         "coefficient" = coefficients,
@@ -200,15 +200,15 @@ msaGaugeLinearity <- function(jaspResults, dataset, options, ...) {
     }
 
     df3 <- data.frame(Source = c("Linearity", "Bias"), Percent = c(percentLin, (abs(averageBias) / options[["manualProcessVariationValue"]]) * 100))
-    yBreaks <- jaspGraphs::getPrettyAxisBreaks(df3$Percent)
+    yBreaks <- jaspGraphs::getPrettyAxisBreaks(c(0, df3$Percent))
     yLimits <- range(yBreaks)
 
     p2 <- ggplot2::ggplot() +
       ggplot2::geom_col(data = df3, mapping = ggplot2::aes(x = Source, y = Percent)) +
       ggplot2::scale_y_continuous(breaks = yBreaks, limits = yLimits) +
-      ggplot2::xlab(ggplot2::element_blank())
-
-    p2 <- jaspGraphs::themeJasp(p2)
+      ggplot2::xlab(ggplot2::element_blank()) +
+      jaspGraphs::geom_rangeframe() +
+      jaspGraphs::themeJaspRaw()
 
     plot2$plotObject <- p2
   }

--- a/R/msaGaugeRR.R
+++ b/R/msaGaugeRR.R
@@ -867,7 +867,7 @@ msaGaugeRR <- function(jaspResults, dataset, options, ...) {
     jaspGraphs::themeJaspRaw() +
     jaspGraphs::geom_rangeframe() +
     ggplot2::theme(legend.position = 'right', legend.title = ggplot2::element_blank()) +
-    ggplot2::xlab("") +
+    ggplot2::xlab(NULL) +
     ggplot2::scale_y_continuous(name = "Percent", breaks = yBreaks, limits = range(c(yBreaks, plotframe$value)))
   return(p)
 }

--- a/R/msaGaugeRR.R
+++ b/R/msaGaugeRR.R
@@ -38,8 +38,8 @@ msaGaugeRR <- function(jaspResults, dataset, options, ...) {
   }  else if (!wideFormat && options[["type3"]]) {
     ready <- (!identical(measurements, "") && !identical(parts, ""))
   }
-  
-    
+
+
   numeric.vars <- measurements
   numeric.vars <- numeric.vars[numeric.vars != ""]
   factor.vars <- c(parts, operators)
@@ -844,10 +844,10 @@ msaGaugeRR <- function(jaspResults, dataset, options, ...) {
 
 .gaugeVarCompGraph <- function(percentContributionValues, studyVariationValues, percentToleranceValues, Type3 = FALSE) {
   sources <- gettext(c('Gauge r&R', 'Repeat', 'Reprod', 'Part-to-Part'))
-  if (!all(is.na(percentToleranceValues))){
+  if (!all(is.na(percentToleranceValues))) {
     references <- gettextf(c('%% Contribution', '%% Study Variation', '%% Tolerance'))
     values <- c(percentContributionValues, studyVariationValues, percentToleranceValues)
-  }else{
+  } else {
     references <- gettextf(c('%% Contribution', '%% Study Variation'))
     values <- c(percentContributionValues, studyVariationValues)
   }
@@ -855,19 +855,21 @@ msaGaugeRR <- function(jaspResults, dataset, options, ...) {
                           reference = rep(references, each = 4),
                           value = values)
   plotframe$source <- factor(plotframe$source, levels = sources)
-  yBreaks <- jaspGraphs::getPrettyAxisBreaks(plotframe$value)
+  yBreaks <- jaspGraphs::getPrettyAxisBreaks(c(0, plotframe$value))
 
 
   if (Type3)
     plotframe <- subset(plotframe, source != "Reprod")
 
-  p <- ggplot2::ggplot() + ggplot2::geom_bar(data = plotframe,
-                                             mapping = ggplot2::aes(fill =  reference,  y = value, x = source),
-                                             position="dodge", stat = "identity")
-  p <- jaspGraphs::themeJasp(p) + ggplot2::theme(legend.position = 'right', legend.title = ggplot2::element_blank()) +
-    ggplot2::xlab("") + ggplot2::scale_y_continuous(name = "Percent", breaks = yBreaks, limits = range(c(yBreaks, plotframe$value)))
+  p <- ggplot2::ggplot() +
+    ggplot2::geom_bar(data = plotframe, mapping = ggplot2::aes(fill =  reference,  y = value, x = source),
+                      position="dodge", stat = "identity") +
+    jaspGraphs::themeJaspRaw() +
+    jaspGraphs::geom_rangeframe() +
+    ggplot2::theme(legend.position = 'right', legend.title = ggplot2::element_blank()) +
+    ggplot2::xlab("") +
+    ggplot2::scale_y_continuous(name = "Percent", breaks = yBreaks, limits = range(c(yBreaks, plotframe$value)))
   return(p)
-
 }
 
 .gaugeNumberDistinctCategories <- function(sdPart, sdGauge) {

--- a/R/processCapabilityStudies.R
+++ b/R/processCapabilityStudies.R
@@ -67,10 +67,16 @@ processCapabilityStudies <- function(jaspResults, dataset, options) {
       measurements <- colnames(dataset)
       subgroups <- ""
     }else{
-      k <- subgroups
-      dataset <- .PClongTowide(dataset, k, measurements, mode = "subgroups")
-      measurements <- colnames(dataset)
-      measurements <- measurements[measurements != k]
+      k <- dataset[[subgroups]]
+      k <- na.omit(k)
+      # add sequence of occurence to allow pivot_wider
+      occurenceVector <- with(dataset, ave(seq_along(k), k, FUN = seq_along))
+      dataset$occurence <- occurenceVector
+      # transform into one group per row
+      dataset <- tidyr::pivot_wider(data = dataset, values_from = tidyr::all_of(measurements), names_from = occurence)
+      # arrange into dataframe
+      dataset <- as.data.frame(dataset)
+      measurements <- as.character(unique(occurenceVector))
     }
   }
 

--- a/tests/testthat/_snaps/msaGaugeLinearity/bias-and-linearity.svg
+++ b/tests/testthat/_snaps/msaGaugeLinearity/bias-and-linearity.svg
@@ -21,112 +21,110 @@
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 </g>
 <defs>
-  <clipPath id='cpNjMuODF8NzIwLjAwfDIwLjcxfDUwNy4wOQ=='>
-    <rect x='63.81' y='20.71' width='656.19' height='486.39' />
+  <clipPath id='cpNjAuNzd8NzIwLjAwfDIwLjcxfDUxMC4xNA=='>
+    <rect x='60.77' y='20.71' width='659.23' height='489.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNjMuODF8NzIwLjAwfDIwLjcxfDUwNy4wOQ==)'>
-<rect x='63.81' y='20.71' width='656.19' height='486.39' style='stroke-width: 10.67; stroke: none;' />
-<line x1='63.81' y1='356.61' x2='720.00' y2='356.61' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
-<polygon points='93.64,273.81 101.19,275.97 108.74,278.12 116.29,280.28 123.84,282.43 131.39,284.58 138.95,286.72 146.50,288.87 154.05,291.01 161.60,293.14 169.15,295.28 176.70,297.41 184.25,299.53 191.80,301.65 199.35,303.77 206.91,305.88 214.46,307.99 222.01,310.09 229.56,312.19 237.11,314.28 244.66,316.37 252.21,318.45 259.76,320.52 267.31,322.59 274.86,324.65 282.42,326.70 289.97,328.74 297.52,330.78 305.07,332.80 312.62,334.82 320.17,336.83 327.72,338.83 335.27,340.82 342.82,342.79 350.38,344.76 357.93,346.72 365.48,348.67 373.03,350.60 380.58,352.53 388.13,354.44 395.68,356.34 403.23,358.23 410.78,360.11 418.33,361.98 425.89,363.84 433.44,365.68 440.99,367.52 448.54,369.34 456.09,371.16 463.64,372.96 471.19,374.76 478.74,376.54 486.29,378.32 493.85,380.09 501.40,381.85 508.95,383.60 516.50,385.35 524.05,387.08 531.60,388.81 539.15,390.54 546.70,392.26 554.25,393.97 561.81,395.67 569.36,397.37 576.91,399.07 584.46,400.76 592.01,402.45 599.56,404.13 607.11,405.81 614.66,407.48 622.21,409.15 629.76,410.82 637.32,412.48 644.87,414.14 652.42,415.80 659.97,417.46 667.52,419.11 675.07,420.76 682.62,422.40 690.17,424.05 690.17,454.64 682.62,452.48 675.07,450.32 667.52,448.17 659.97,446.01 652.42,443.87 644.87,441.72 637.32,439.58 629.76,437.44 622.21,435.30 614.66,433.17 607.11,431.04 599.56,428.91 592.01,426.79 584.46,424.67 576.91,422.56 569.36,420.45 561.81,418.35 554.25,416.25 546.70,414.16 539.15,412.07 531.60,410.00 524.05,407.92 516.50,405.86 508.95,403.80 501.40,401.75 493.85,399.70 486.29,397.67 478.74,395.64 471.19,393.62 463.64,391.61 456.09,389.62 448.54,387.63 440.99,385.65 433.44,383.68 425.89,381.72 418.33,379.78 410.78,377.84 403.23,375.92 395.68,374.00 388.13,372.10 380.58,370.21 373.03,368.33 365.48,366.46 357.93,364.61 350.38,362.76 342.82,360.92 335.27,359.10 327.72,357.29 320.17,355.48 312.62,353.68 305.07,351.90 297.52,350.12 289.97,348.35 282.42,346.59 274.86,344.84 267.31,343.10 259.76,341.36 252.21,339.63 244.66,337.90 237.11,336.19 229.56,334.47 222.01,332.77 214.46,331.07 206.91,329.37 199.35,327.68 191.80,325.99 184.25,324.31 176.70,322.63 169.15,320.96 161.60,319.29 154.05,317.62 146.50,315.96 138.95,314.30 131.39,312.64 123.84,310.99 116.29,309.33 108.74,307.68 101.19,306.04 93.64,304.39 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
-<polyline points='93.64,273.81 101.19,275.97 108.74,278.12 116.29,280.28 123.84,282.43 131.39,284.58 138.95,286.72 146.50,288.87 154.05,291.01 161.60,293.14 169.15,295.28 176.70,297.41 184.25,299.53 191.80,301.65 199.35,303.77 206.91,305.88 214.46,307.99 222.01,310.09 229.56,312.19 237.11,314.28 244.66,316.37 252.21,318.45 259.76,320.52 267.31,322.59 274.86,324.65 282.42,326.70 289.97,328.74 297.52,330.78 305.07,332.80 312.62,334.82 320.17,336.83 327.72,338.83 335.27,340.82 342.82,342.79 350.38,344.76 357.93,346.72 365.48,348.67 373.03,350.60 380.58,352.53 388.13,354.44 395.68,356.34 403.23,358.23 410.78,360.11 418.33,361.98 425.89,363.84 433.44,365.68 440.99,367.52 448.54,369.34 456.09,371.16 463.64,372.96 471.19,374.76 478.74,376.54 486.29,378.32 493.85,380.09 501.40,381.85 508.95,383.60 516.50,385.35 524.05,387.08 531.60,388.81 539.15,390.54 546.70,392.26 554.25,393.97 561.81,395.67 569.36,397.37 576.91,399.07 584.46,400.76 592.01,402.45 599.56,404.13 607.11,405.81 614.66,407.48 622.21,409.15 629.76,410.82 637.32,412.48 644.87,414.14 652.42,415.80 659.97,417.46 667.52,419.11 675.07,420.76 682.62,422.40 690.17,424.05 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
-<polyline points='690.17,454.64 682.62,452.48 675.07,450.32 667.52,448.17 659.97,446.01 652.42,443.87 644.87,441.72 637.32,439.58 629.76,437.44 622.21,435.30 614.66,433.17 607.11,431.04 599.56,428.91 592.01,426.79 584.46,424.67 576.91,422.56 569.36,420.45 561.81,418.35 554.25,416.25 546.70,414.16 539.15,412.07 531.60,410.00 524.05,407.92 516.50,405.86 508.95,403.80 501.40,401.75 493.85,399.70 486.29,397.67 478.74,395.64 471.19,393.62 463.64,391.61 456.09,389.62 448.54,387.63 440.99,385.65 433.44,383.68 425.89,381.72 418.33,379.78 410.78,377.84 403.23,375.92 395.68,374.00 388.13,372.10 380.58,370.21 373.03,368.33 365.48,366.46 357.93,364.61 350.38,362.76 342.82,360.92 335.27,359.10 327.72,357.29 320.17,355.48 312.62,353.68 305.07,351.90 297.52,350.12 289.97,348.35 282.42,346.59 274.86,344.84 267.31,343.10 259.76,341.36 252.21,339.63 244.66,337.90 237.11,336.19 229.56,334.47 222.01,332.77 214.46,331.07 206.91,329.37 199.35,327.68 191.80,325.99 184.25,324.31 176.70,322.63 169.15,320.96 161.60,319.29 154.05,317.62 146.50,315.96 138.95,314.30 131.39,312.64 123.84,310.99 116.29,309.33 108.74,307.68 101.19,306.04 93.64,304.39 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
-<polyline points='93.64,289.10 101.19,291.00 108.74,292.90 116.29,294.81 123.84,296.71 131.39,298.61 138.95,300.51 146.50,302.41 154.05,304.31 161.60,306.22 169.15,308.12 176.70,310.02 184.25,311.92 191.80,313.82 199.35,315.73 206.91,317.63 214.46,319.53 222.01,321.43 229.56,323.33 237.11,325.23 244.66,327.14 252.21,329.04 259.76,330.94 267.31,332.84 274.86,334.74 282.42,336.64 289.97,338.55 297.52,340.45 305.07,342.35 312.62,344.25 320.17,346.15 327.72,348.06 335.27,349.96 342.82,351.86 350.38,353.76 357.93,355.66 365.48,357.56 373.03,359.47 380.58,361.37 388.13,363.27 395.68,365.17 403.23,367.07 410.78,368.98 418.33,370.88 425.89,372.78 433.44,374.68 440.99,376.58 448.54,378.48 456.09,380.39 463.64,382.29 471.19,384.19 478.74,386.09 486.29,387.99 493.85,389.90 501.40,391.80 508.95,393.70 516.50,395.60 524.05,397.50 531.60,399.40 539.15,401.31 546.70,403.21 554.25,405.11 561.81,407.01 569.36,408.91 576.91,410.82 584.46,412.72 592.01,414.62 599.56,416.52 607.11,418.42 614.66,420.32 622.21,422.23 629.76,424.13 637.32,426.03 644.87,427.93 652.42,429.83 659.97,431.74 667.52,433.64 675.07,435.54 682.62,437.44 690.17,439.34 ' style='stroke-width: 2.13; stroke: #FF0000; stroke-linecap: butt;' />
-<text x='93.64' y='261.01' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='93.64' y='289.54' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='93.64' y='303.80' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='93.64' y='289.54' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='93.64' y='261.01' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='93.64' y='318.06' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='93.64' y='289.54' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='93.64' y='289.54' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='93.64' y='303.80' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='93.64' y='303.80' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='93.64' y='275.27' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='93.64' y='303.80' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='242.77' y='203.96' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='242.77' y='375.12' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='242.77' y='332.33' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='242.77' y='218.22' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='242.77' y='389.38' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='242.77' y='375.12' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='242.77' y='375.12' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='242.77' y='375.12' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='242.77' y='375.12' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='242.77' y='360.86' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='242.77' y='346.59' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='242.77' y='389.38' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='391.91' y='389.38' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='391.91' y='403.65' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='391.91' y='375.12' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='391.91' y='375.12' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='391.91' y='360.86' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='391.91' y='346.59' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='391.91' y='360.86' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='391.91' y='346.59' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='391.91' y='303.80' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='391.91' y='318.06' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='391.91' y='360.86' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='391.91' y='346.59' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='541.04' y='417.91' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='541.04' y='403.65' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='541.04' y='389.38' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='541.04' y='403.65' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='541.04' y='389.38' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='541.04' y='389.38' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='541.04' y='389.38' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='541.04' y='403.65' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='541.04' y='389.38' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='541.04' y='432.17' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='541.04' y='417.91' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='541.04' y='403.65' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='690.17' y='489.23' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='690.17' y='460.70' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='690.17' y='432.17' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='690.17' y='460.70' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='690.17' y='446.44' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='690.17' y='432.17' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='690.17' y='432.17' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='690.17' y='432.17' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='690.17' y='417.91' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='690.17' y='474.96' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='690.17' y='460.70' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<text x='690.17' y='446.44' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
-<circle cx='93.64' cy='286.48' r='4.62' style='stroke-width: 0.71; fill: #FF0000;' />
-<circle cx='242.77' cy='338.78' r='4.62' style='stroke-width: 0.71; fill: #FF0000;' />
-<circle cx='391.91' cy='353.05' r='4.62' style='stroke-width: 0.71; fill: #FF0000;' />
-<circle cx='541.04' cy='398.22' r='4.62' style='stroke-width: 0.71; fill: #FF0000;' />
-<circle cx='690.17' cy='444.57' r='4.62' style='stroke-width: 0.71; fill: #FF0000;' />
-<text x='391.91' y='165.88' text-anchor='middle' style='font-size: 15.65px; font-family: sans;' textLength='108.33px' lengthAdjust='spacingAndGlyphs'>y = 0.74 - 0.13x</text>
-<line x1='93.32' y1='507.09' x2='690.49' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='63.81' y1='499.57' x2='63.81' y2='71.02' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='93.32' y1='507.09' x2='690.49' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='63.81' y1='499.57' x2='63.81' y2='71.02' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<rect x='63.81' y='20.71' width='656.19' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+<g clip-path='url(#cpNjAuNzd8NzIwLjAwfDIwLjcxfDUxMC4xNA==)'>
+<rect x='60.77' y='20.71' width='659.23' height='489.43' style='stroke-width: 10.67; stroke: none;' />
+<line x1='60.77' y1='358.72' x2='720.00' y2='358.72' style='stroke-width: 1.07; stroke: #BEBEBE; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
+<polygon points='90.73,275.39 98.32,277.56 105.90,279.73 113.49,281.90 121.08,284.07 128.66,286.23 136.25,288.39 143.83,290.55 151.42,292.70 159.01,294.85 166.59,297.00 174.18,299.14 181.77,301.28 189.35,303.41 196.94,305.54 204.52,307.67 212.11,309.79 219.70,311.90 227.28,314.02 234.87,316.12 242.45,318.22 250.04,320.31 257.63,322.40 265.21,324.48 272.80,326.55 280.38,328.61 287.97,330.67 295.56,332.72 303.14,334.76 310.73,336.79 318.32,338.81 325.90,340.82 333.49,342.82 341.07,344.81 348.66,346.79 356.25,348.76 363.83,350.72 371.42,352.67 379.00,354.60 386.59,356.53 394.18,358.44 401.76,360.35 409.35,362.24 416.93,364.12 424.52,365.98 432.11,367.84 439.69,369.69 447.28,371.53 454.87,373.35 462.45,375.17 470.04,376.97 477.62,378.77 485.21,380.56 492.80,382.34 500.38,384.11 507.97,385.87 515.55,387.63 523.14,389.38 530.73,391.12 538.31,392.85 545.90,394.58 553.48,396.30 561.07,398.02 568.66,399.73 576.24,401.44 583.83,403.14 591.42,404.84 599.00,406.53 606.59,408.22 614.17,409.90 621.76,411.58 629.35,413.26 636.93,414.94 644.52,416.61 652.10,418.28 659.69,419.94 667.28,421.60 674.86,423.26 682.45,424.92 690.03,426.58 690.03,457.35 682.45,455.18 674.86,453.01 667.28,450.84 659.69,448.68 652.10,446.52 644.52,444.36 636.93,442.20 629.35,440.05 621.76,437.90 614.17,435.75 606.59,433.61 599.00,431.47 591.42,429.33 583.83,427.20 576.24,425.08 568.66,422.96 561.07,420.84 553.48,418.73 545.90,416.62 538.31,414.53 530.73,412.43 523.14,410.35 515.55,408.27 507.97,406.20 500.38,404.13 492.80,402.08 485.21,400.03 477.62,397.99 470.04,395.96 462.45,393.94 454.87,391.93 447.28,389.92 439.69,387.93 432.11,385.95 424.52,383.98 416.93,382.02 409.35,380.08 401.76,378.14 394.18,376.22 386.59,374.30 379.00,372.40 371.42,370.51 363.83,368.63 356.25,366.76 348.66,364.90 341.07,363.06 333.49,361.22 325.90,359.39 318.32,357.58 310.73,355.77 303.14,353.97 295.56,352.18 287.97,350.41 280.38,348.63 272.80,346.87 265.21,345.12 257.63,343.37 250.04,341.63 242.45,339.89 234.87,338.16 227.28,336.44 219.70,334.72 212.11,333.01 204.52,331.30 196.94,329.60 189.35,327.91 181.77,326.21 174.18,324.52 166.59,322.84 159.01,321.16 151.42,319.48 143.83,317.81 136.25,316.14 128.66,314.47 121.08,312.80 113.49,311.14 105.90,309.48 98.32,307.82 90.73,306.17 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #999999; fill-opacity: 0.40;' />
+<polyline points='90.73,275.39 98.32,277.56 105.90,279.73 113.49,281.90 121.08,284.07 128.66,286.23 136.25,288.39 143.83,290.55 151.42,292.70 159.01,294.85 166.59,297.00 174.18,299.14 181.77,301.28 189.35,303.41 196.94,305.54 204.52,307.67 212.11,309.79 219.70,311.90 227.28,314.02 234.87,316.12 242.45,318.22 250.04,320.31 257.63,322.40 265.21,324.48 272.80,326.55 280.38,328.61 287.97,330.67 295.56,332.72 303.14,334.76 310.73,336.79 318.32,338.81 325.90,340.82 333.49,342.82 341.07,344.81 348.66,346.79 356.25,348.76 363.83,350.72 371.42,352.67 379.00,354.60 386.59,356.53 394.18,358.44 401.76,360.35 409.35,362.24 416.93,364.12 424.52,365.98 432.11,367.84 439.69,369.69 447.28,371.53 454.87,373.35 462.45,375.17 470.04,376.97 477.62,378.77 485.21,380.56 492.80,382.34 500.38,384.11 507.97,385.87 515.55,387.63 523.14,389.38 530.73,391.12 538.31,392.85 545.90,394.58 553.48,396.30 561.07,398.02 568.66,399.73 576.24,401.44 583.83,403.14 591.42,404.84 599.00,406.53 606.59,408.22 614.17,409.90 621.76,411.58 629.35,413.26 636.93,414.94 644.52,416.61 652.10,418.28 659.69,419.94 667.28,421.60 674.86,423.26 682.45,424.92 690.03,426.58 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='690.03,457.35 682.45,455.18 674.86,453.01 667.28,450.84 659.69,448.68 652.10,446.52 644.52,444.36 636.93,442.20 629.35,440.05 621.76,437.90 614.17,435.75 606.59,433.61 599.00,431.47 591.42,429.33 583.83,427.20 576.24,425.08 568.66,422.96 561.07,420.84 553.48,418.73 545.90,416.62 538.31,414.53 530.73,412.43 523.14,410.35 515.55,408.27 507.97,406.20 500.38,404.13 492.80,402.08 485.21,400.03 477.62,397.99 470.04,395.96 462.45,393.94 454.87,391.93 447.28,389.92 439.69,387.93 432.11,385.95 424.52,383.98 416.93,382.02 409.35,380.08 401.76,378.14 394.18,376.22 386.59,374.30 379.00,372.40 371.42,370.51 363.83,368.63 356.25,366.76 348.66,364.90 341.07,363.06 333.49,361.22 325.90,359.39 318.32,357.58 310.73,355.77 303.14,353.97 295.56,352.18 287.97,350.41 280.38,348.63 272.80,346.87 265.21,345.12 257.63,343.37 250.04,341.63 242.45,339.89 234.87,338.16 227.28,336.44 219.70,334.72 212.11,333.01 204.52,331.30 196.94,329.60 189.35,327.91 181.77,326.21 174.18,324.52 166.59,322.84 159.01,321.16 151.42,319.48 143.83,317.81 136.25,316.14 128.66,314.47 121.08,312.80 113.49,311.14 105.90,309.48 98.32,307.82 90.73,306.17 ' style='stroke-width: 2.13; stroke: none; stroke-linecap: butt;' />
+<polyline points='90.73,290.78 98.32,292.69 105.90,294.61 113.49,296.52 121.08,298.44 128.66,300.35 136.25,302.26 143.83,304.18 151.42,306.09 159.01,308.00 166.59,309.92 174.18,311.83 181.77,313.75 189.35,315.66 196.94,317.57 204.52,319.49 212.11,321.40 219.70,323.31 227.28,325.23 234.87,327.14 242.45,329.05 250.04,330.97 257.63,332.88 265.21,334.80 272.80,336.71 280.38,338.62 287.97,340.54 295.56,342.45 303.14,344.36 310.73,346.28 318.32,348.19 325.90,350.11 333.49,352.02 341.07,353.93 348.66,355.85 356.25,357.76 363.83,359.67 371.42,361.59 379.00,363.50 386.59,365.42 394.18,367.33 401.76,369.24 409.35,371.16 416.93,373.07 424.52,374.98 432.11,376.90 439.69,378.81 447.28,380.73 454.87,382.64 462.45,384.55 470.04,386.47 477.62,388.38 485.21,390.29 492.80,392.21 500.38,394.12 507.97,396.03 515.55,397.95 523.14,399.86 530.73,401.78 538.31,403.69 545.90,405.60 553.48,407.52 561.07,409.43 568.66,411.34 576.24,413.26 583.83,415.17 591.42,417.09 599.00,419.00 606.59,420.91 614.17,422.83 621.76,424.74 629.35,426.65 636.93,428.57 644.52,430.48 652.10,432.40 659.69,434.31 667.28,436.22 674.86,438.14 682.45,440.05 690.03,441.96 ' style='stroke-width: 2.13; stroke: #FF0000; stroke-linecap: butt;' />
+<text x='90.73' y='262.49' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='90.73' y='291.19' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='90.73' y='305.55' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='90.73' y='291.19' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='90.73' y='262.49' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='90.73' y='319.90' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='90.73' y='291.19' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='90.73' y='291.19' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='90.73' y='305.55' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='90.73' y='305.55' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='90.73' y='276.84' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='90.73' y='305.55' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='240.56' y='205.08' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='240.56' y='377.31' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='240.56' y='334.25' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='240.56' y='219.43' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='240.56' y='391.66' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='240.56' y='377.31' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='240.56' y='377.31' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='240.56' y='377.31' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='240.56' y='377.31' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='240.56' y='362.96' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='240.56' y='348.61' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='240.56' y='391.66' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='390.38' y='391.66' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='390.38' y='406.02' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='390.38' y='377.31' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='390.38' y='377.31' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='390.38' y='362.96' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='390.38' y='348.61' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='390.38' y='362.96' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='390.38' y='348.61' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='390.38' y='305.55' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='390.38' y='319.90' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='390.38' y='362.96' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='390.38' y='348.61' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='540.21' y='420.37' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='540.21' y='406.02' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='540.21' y='391.66' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='540.21' y='406.02' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='540.21' y='391.66' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='540.21' y='391.66' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='540.21' y='391.66' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='540.21' y='406.02' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='540.21' y='391.66' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='540.21' y='434.72' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='540.21' y='420.37' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='540.21' y='406.02' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='690.03' y='492.13' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='690.03' y='463.43' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='690.03' y='434.72' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='690.03' y='463.43' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='690.03' y='449.08' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='690.03' y='434.72' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='690.03' y='434.72' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='690.03' y='434.72' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='690.03' y='420.37' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='690.03' y='477.78' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='690.03' y='463.43' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<text x='690.03' y='449.08' text-anchor='middle' style='font-size: 12.33px; font-family: sans;' textLength='8.22px' lengthAdjust='spacingAndGlyphs'>X</text>
+<circle cx='90.73' cy='288.15' r='4.62' style='stroke-width: 0.71; fill: #FF0000;' />
+<circle cx='240.56' cy='340.78' r='4.62' style='stroke-width: 0.71; fill: #FF0000;' />
+<circle cx='390.38' cy='355.13' r='4.62' style='stroke-width: 0.71; fill: #FF0000;' />
+<circle cx='540.21' cy='400.58' r='4.62' style='stroke-width: 0.71; fill: #FF0000;' />
+<circle cx='690.03' cy='447.23' r='4.62' style='stroke-width: 0.71; fill: #FF0000;' />
+<text x='390.38' y='166.75' text-anchor='middle' style='font-size: 15.65px; font-family: sans;' textLength='108.33px' lengthAdjust='spacingAndGlyphs'>y = 0.74 - 0.13x</text>
+<line x1='90.41' y1='510.14' x2='690.35' y2='510.14' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='60.77' y1='502.56' x2='60.77' y2='71.34' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='60.77' y='20.71' width='659.23' height='489.43' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='63.81,507.09 63.81,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<text x='48.33' y='505.10' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-1</text>
-<text x='48.33' y='362.46' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='48.33' y='219.83' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='48.33' y='77.19' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
-<polyline points='55.31,499.25 63.81,499.25 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='55.31,356.61 63.81,356.61 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='55.31,213.98 63.81,213.98 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='55.31,71.34 63.81,71.34 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='63.81,507.09 720.00,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<polyline points='93.64,515.60 93.64,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='242.77,515.60 242.77,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='391.91,515.60 391.91,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='541.04,515.60 541.04,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='690.17,515.60 690.17,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<text x='93.64' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='242.77' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='391.91' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='541.04' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>8</text>
-<text x='690.17' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='391.91' y='566.78' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='94.14px' lengthAdjust='spacingAndGlyphs'>Reference</text>
-<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='39.69px' lengthAdjust='spacingAndGlyphs'>Bias</text>
-<text x='391.91' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='129.46px' lengthAdjust='spacingAndGlyphs'>bias-and-linearity</text>
+<polyline points='60.77,510.14 60.77,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='45.29' y='508.10' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='45.29' y='364.57' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='45.29' y='221.04' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='45.29' y='77.51' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polyline points='52.26,502.25 60.77,502.25 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='52.26,358.72 60.77,358.72 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='52.26,215.19 60.77,215.19 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='52.26,71.66 60.77,71.66 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='60.77,510.14 720.00,510.14 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='90.73,518.64 90.73,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='240.56,518.64 240.56,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='390.38,518.64 390.38,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='540.21,518.64 540.21,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='690.03,518.64 690.03,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='90.73' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='240.56' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='390.38' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='540.21' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='690.03' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='390.38' y='567.49' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='78.45px' lengthAdjust='spacingAndGlyphs'>Reference</text>
+<text transform='translate(16.68,265.42) rotate(-90)' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.08px' lengthAdjust='spacingAndGlyphs'>Bias</text>
+<text x='390.38' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='129.46px' lengthAdjust='spacingAndGlyphs'>bias-and-linearity</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/msaGaugeLinearity/percentage-process-variation-graph.svg
+++ b/tests/testthat/_snaps/msaGaugeLinearity/percentage-process-variation-graph.svg
@@ -21,42 +21,42 @@
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 </g>
 <defs>
-  <clipPath id='cpNjcuNjF8NzIwLjAwfDIwLjcxfDUyMS4xMw=='>
-    <rect x='67.61' y='20.71' width='652.39' height='500.43' />
+  <clipPath id='cpNjQuNTZ8NzIwLjAwfDIwLjcxfDUyMS44NA=='>
+    <rect x='64.56' y='20.71' width='655.44' height='501.13' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNjcuNjF8NzIwLjAwfDIwLjcxfDUyMS4xMw==)'>
-<rect x='67.61' y='20.71' width='652.39' height='500.43' style='stroke-width: 10.67; stroke: none;' />
-<rect x='408.63' y='70.53' width='266.89' height='427.85' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
-<rect x='112.09' y='469.50' width='266.89' height='28.88' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
-<line x1='245.21' y1='521.13' x2='542.39' y2='521.13' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='67.61' y1='498.71' x2='67.61' y2='43.14' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<rect x='67.61' y='20.71' width='652.39' height='500.43' style='stroke-width: 0.00; stroke: none;' />
+<g clip-path='url(#cpNjQuNTZ8NzIwLjAwfDIwLjcxfDUyMS44NA==)'>
+<rect x='64.56' y='20.71' width='655.44' height='501.13' style='stroke-width: 10.67; stroke: none;' />
+<rect x='407.18' y='70.60' width='268.13' height='428.46' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<rect x='109.25' y='470.14' width='268.13' height='28.93' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #595959;' />
+<line x1='243.00' y1='521.84' x2='541.56' y2='521.84' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='64.56' y1='499.38' x2='64.56' y2='43.17' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='64.56' y='20.71' width='655.44' height='501.13' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='67.61,521.13 67.61,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<text x='52.13' y='504.24' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='52.13' y='439.25' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='52.13' y='374.26' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='52.13' y='309.27' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='52.13' y='244.28' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>8</text>
-<text x='52.13' y='179.28' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='52.13' y='114.29' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>12</text>
-<text x='52.13' y='49.30' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>14</text>
-<polyline points='59.10,498.39 67.61,498.39 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='59.10,433.40 67.61,433.40 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='59.10,368.41 67.61,368.41 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='59.10,303.42 67.61,303.42 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='59.10,238.43 67.61,238.43 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='59.10,173.44 67.61,173.44 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='59.10,108.44 67.61,108.44 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='59.10,43.45 67.61,43.45 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='67.61,521.13 720.00,521.13 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<polyline points='245.53,529.64 245.53,521.13 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='542.07,529.64 542.07,521.13 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<text x='245.53' y='548.31' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.08px' lengthAdjust='spacingAndGlyphs'>Bias</text>
-<text x='542.07' y='548.31' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='64.26px' lengthAdjust='spacingAndGlyphs'>Linearity</text>
-<text transform='translate(19.02,270.92) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='70.32px' lengthAdjust='spacingAndGlyphs'>Percent</text>
-<text x='393.80' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='269.35px' lengthAdjust='spacingAndGlyphs'>percentage-process-variation-graph</text>
+<polyline points='64.56,521.84 64.56,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='49.08' y='504.91' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='49.08' y='439.83' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='49.08' y='374.75' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='49.08' y='309.66' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='49.08' y='244.58' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>8</text>
+<text x='49.08' y='179.50' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='49.08' y='114.42' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>12</text>
+<text x='49.08' y='49.34' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>14</text>
+<polyline points='56.06,499.06 64.56,499.06 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='56.06,433.98 64.56,433.98 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='56.06,368.90 64.56,368.90 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='56.06,303.81 64.56,303.81 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='56.06,238.73 64.56,238.73 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='56.06,173.65 64.56,173.65 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='56.06,108.57 64.56,108.57 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='56.06,43.49 64.56,43.49 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='64.56,521.84 720.00,521.84 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='243.32,530.34 243.32,521.84 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='541.24,530.34 541.24,521.84 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='243.32' y='549.02' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='33.08px' lengthAdjust='spacingAndGlyphs'>Bias</text>
+<text x='541.24' y='549.02' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='64.26px' lengthAdjust='spacingAndGlyphs'>Linearity</text>
+<text transform='translate(16.68,271.27) rotate(-90)' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='58.60px' lengthAdjust='spacingAndGlyphs'>Percent</text>
+<text x='392.28' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='269.35px' lengthAdjust='spacingAndGlyphs'>percentage-process-variation-graph</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/msaGaugeRR/components-of-variation-longtype3.svg
+++ b/tests/testthat/_snaps/msaGaugeRR/components-of-variation-longtype3.svg
@@ -18,50 +18,50 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+<rect x='-0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 </g>
 <defs>
-  <clipPath id='cpNzcuMDZ8NTI2LjEzfDIwLjcxfDUwNy4wOQ=='>
-    <rect x='77.06' y='20.71' width='449.07' height='486.39' />
+  <clipPath id='cpNzQuMDJ8NTI2LjEzfDIwLjcxfDUxMC4xNA=='>
+    <rect x='74.02' y='20.71' width='452.11' height='489.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNzcuMDZ8NTI2LjEzfDIwLjcxfDUwNy4wOQ==)'>
-<rect x='77.06' y='20.71' width='449.07' height='486.39' style='stroke-width: 10.67; stroke: none;' />
-<rect x='98.11' y='464.97' width='42.10' height='20.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='238.45' y='464.97' width='42.10' height='20.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='378.78' y='62.83' width='42.10' height='422.16' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='140.21' y='390.92' width='42.10' height='94.07' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='280.55' y='390.92' width='42.10' height='94.07' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='420.88' y='52.94' width='42.10' height='432.05' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='182.31' y='392.02' width='42.10' height='92.97' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<rect x='322.64' y='392.02' width='42.10' height='92.97' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<rect x='462.98' y='57.98' width='42.10' height='427.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<line x1='160.94' y1='507.09' x2='442.25' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='77.06' y1='485.30' x2='77.06' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<rect x='77.06' y='20.71' width='449.07' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+<g clip-path='url(#cpNzQuMDJ8NTI2LjEzfDIwLjcxfDUxMC4xNA==)'>
+<rect x='74.02' y='20.71' width='452.11' height='489.43' style='stroke-width: 10.67; stroke: none;' />
+<rect x='95.21' y='467.76' width='42.39' height='20.14' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='236.49' y='467.76' width='42.39' height='20.14' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='377.78' y='63.09' width='42.39' height='424.80' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='137.59' y='393.24' width='42.39' height='94.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='278.88' y='393.24' width='42.39' height='94.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='420.16' y='53.14' width='42.39' height='434.75' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='179.98' y='394.34' width='42.39' height='93.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<rect x='321.26' y='394.34' width='42.39' height='93.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<rect x='462.55' y='58.21' width='42.39' height='429.68' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<line x1='158.47' y1='510.14' x2='441.68' y2='510.14' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='74.02' y1='488.21' x2='74.02' y2='42.64' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='74.02' y='20.71' width='452.11' height='489.43' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='77.06,507.09 77.06,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<text x='61.58' y='490.84' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='61.58' y='402.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='61.58' y='313.97' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>40</text>
-<text x='61.58' y='225.53' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>60</text>
-<text x='61.58' y='137.10' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>80</text>
-<text x='61.58' y='48.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>100</text>
-<polyline points='68.56,484.99 77.06,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,396.55 77.06,396.55 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,308.12 77.06,308.12 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,219.68 77.06,219.68 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,131.25 77.06,131.25 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,42.82 77.06,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='77.06,507.09 526.13,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<polyline points='161.26,515.60 161.26,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='301.59,515.60 301.59,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='441.93,515.60 441.93,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<text x='161.26' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='85.06px' lengthAdjust='spacingAndGlyphs'>Gauge r&amp;R</text>
-<text x='301.59' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='54.82px' lengthAdjust='spacingAndGlyphs'>Repeat</text>
-<text x='441.93' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='87.86px' lengthAdjust='spacingAndGlyphs'>Part-to-Part</text>
-<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='70.32px' lengthAdjust='spacingAndGlyphs'>Percent</text>
+<polyline points='74.02,510.14 74.02,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='58.54' y='493.74' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='58.54' y='404.75' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='58.54' y='315.77' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='58.54' y='226.78' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='58.54' y='137.79' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='58.54' y='48.80' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>100</text>
+<polyline points='65.51,487.89 74.02,487.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,398.91 74.02,398.91 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,309.92 74.02,309.92 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,220.93 74.02,220.93 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,131.94 74.02,131.94 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,42.95 74.02,42.95 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='74.02,510.14 526.13,510.14 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='158.79,518.64 158.79,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='300.07,518.64 300.07,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='441.36,518.64 441.36,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='158.79' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='85.06px' lengthAdjust='spacingAndGlyphs'>Gauge r&amp;R</text>
+<text x='300.07' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='54.82px' lengthAdjust='spacingAndGlyphs'>Repeat</text>
+<text x='441.36' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='87.86px' lengthAdjust='spacingAndGlyphs'>Part-to-Part</text>
+<text transform='translate(16.68,265.42) rotate(-90)' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='58.60px' lengthAdjust='spacingAndGlyphs'>Percent</text>
 <rect x='537.09' y='20.71' width='182.91' height='104.47' style='stroke-width: 0.75; stroke: none;' />
 <rect x='537.09' y='20.71' width='182.91' height='104.47' style='stroke-width: 10.67; stroke: none;' />
 <rect x='542.57' y='34.66' width='28.35' height='28.35' style='stroke-width: 10.67; stroke: none;' />
@@ -73,6 +73,6 @@
 <text x='579.38' y='54.68' style='font-size: 17.00px; font-family: sans;' textLength='111.51px' lengthAdjust='spacingAndGlyphs'>% Contribution</text>
 <text x='579.38' y='83.03' style='font-size: 17.00px; font-family: sans;' textLength='135.14px' lengthAdjust='spacingAndGlyphs'>% Study Variation</text>
 <text x='579.38' y='111.37' style='font-size: 17.00px; font-family: sans;' textLength='95.44px' lengthAdjust='spacingAndGlyphs'>% Tolerance</text>
-<text x='301.59' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='273.14px' lengthAdjust='spacingAndGlyphs'>components-of-variation-LongType3</text>
+<text x='300.07' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='273.14px' lengthAdjust='spacingAndGlyphs'>components-of-variation-LongType3</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/msaGaugeRR/components-of-variation-wide.svg
+++ b/tests/testthat/_snaps/msaGaugeRR/components-of-variation-wide.svg
@@ -18,55 +18,55 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+<rect x='-0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 </g>
 <defs>
-  <clipPath id='cpNzcuMDZ8NTI2LjEzfDIwLjcxfDUwNy4wOQ=='>
-    <rect x='77.06' y='20.71' width='449.07' height='486.39' />
+  <clipPath id='cpNzQuMDJ8NTI2LjEzfDIwLjcxfDUxMC4xNA=='>
+    <rect x='74.02' y='20.71' width='452.11' height='489.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNzcuMDZ8NTI2LjEzfDIwLjcxfDUwNy4wOQ==)'>
-<rect x='77.06' y='20.71' width='449.07' height='486.39' style='stroke-width: 10.67; stroke: none;' />
-<rect x='93.10' y='385.24' width='32.08' height='99.75' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='200.02' y='385.32' width='32.08' height='99.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='306.94' y='484.90' width='32.08' height='0.083' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='413.86' y='142.56' width='32.08' height='342.42' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='125.18' y='274.97' width='32.08' height='210.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='232.10' y='275.06' width='32.08' height='209.92' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='339.02' y='478.94' width='32.08' height='6.05' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='445.94' y='95.87' width='32.08' height='389.11' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='157.25' y='322.09' width='32.08' height='162.89' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<rect x='264.17' y='322.16' width='32.08' height='162.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<rect x='371.09' y='480.30' width='32.08' height='4.69' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<rect x='478.01' y='183.17' width='32.08' height='301.81' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<line x1='140.90' y1='507.09' x2='462.29' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='77.06' y1='485.30' x2='77.06' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<rect x='77.06' y='20.71' width='449.07' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+<g clip-path='url(#cpNzQuMDJ8NTI2LjEzfDIwLjcxfDUxMC4xNA==)'>
+<rect x='74.02' y='20.71' width='452.11' height='489.43' style='stroke-width: 10.67; stroke: none;' />
+<rect x='90.16' y='387.52' width='32.29' height='100.37' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='197.81' y='387.61' width='32.29' height='100.29' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='305.45' y='487.81' width='32.29' height='0.083' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='413.10' y='143.33' width='32.29' height='344.57' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='122.46' y='276.57' width='32.29' height='211.33' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='230.10' y='276.65' width='32.29' height='211.24' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='337.75' y='481.81' width='32.29' height='6.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='445.39' y='96.34' width='32.29' height='391.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='154.75' y='323.98' width='32.29' height='163.91' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<rect x='262.40' y='324.05' width='32.29' height='163.85' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<rect x='370.04' y='483.17' width='32.29' height='4.72' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<rect x='477.69' y='184.19' width='32.29' height='303.70' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<line x1='138.28' y1='510.14' x2='461.86' y2='510.14' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='74.02' y1='488.21' x2='74.02' y2='42.64' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='74.02' y='20.71' width='452.11' height='489.43' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='77.06,507.09 77.06,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<text x='61.58' y='490.84' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='61.58' y='402.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='61.58' y='313.97' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>40</text>
-<text x='61.58' y='225.53' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>60</text>
-<text x='61.58' y='137.10' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>80</text>
-<text x='61.58' y='48.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>100</text>
-<polyline points='68.56,484.99 77.06,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,396.55 77.06,396.55 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,308.12 77.06,308.12 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,219.68 77.06,219.68 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,131.25 77.06,131.25 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,42.82 77.06,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='77.06,507.09 526.13,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<polyline points='141.21,515.60 141.21,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='248.13,515.60 248.13,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='355.06,515.60 355.06,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='461.98,515.60 461.98,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<text x='141.21' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='85.06px' lengthAdjust='spacingAndGlyphs'>Gauge r&amp;R</text>
-<text x='248.13' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='54.82px' lengthAdjust='spacingAndGlyphs'>Repeat</text>
-<text x='355.06' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='55.76px' lengthAdjust='spacingAndGlyphs'>Reprod</text>
-<text x='461.98' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='87.86px' lengthAdjust='spacingAndGlyphs'>Part-to-Part</text>
-<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='70.32px' lengthAdjust='spacingAndGlyphs'>Percent</text>
+<polyline points='74.02,510.14 74.02,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='58.54' y='493.74' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='58.54' y='404.75' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='58.54' y='315.77' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='58.54' y='226.78' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='58.54' y='137.79' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='58.54' y='48.80' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>100</text>
+<polyline points='65.51,487.89 74.02,487.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,398.91 74.02,398.91 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,309.92 74.02,309.92 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,220.93 74.02,220.93 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,131.94 74.02,131.94 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,42.95 74.02,42.95 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='74.02,510.14 526.13,510.14 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='138.60,518.64 138.60,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='246.25,518.64 246.25,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='353.89,518.64 353.89,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='461.54,518.64 461.54,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='138.60' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='85.06px' lengthAdjust='spacingAndGlyphs'>Gauge r&amp;R</text>
+<text x='246.25' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='54.82px' lengthAdjust='spacingAndGlyphs'>Repeat</text>
+<text x='353.89' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='55.76px' lengthAdjust='spacingAndGlyphs'>Reprod</text>
+<text x='461.54' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='87.86px' lengthAdjust='spacingAndGlyphs'>Part-to-Part</text>
+<text transform='translate(16.68,265.42) rotate(-90)' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='58.60px' lengthAdjust='spacingAndGlyphs'>Percent</text>
 <rect x='537.09' y='20.71' width='182.91' height='104.47' style='stroke-width: 0.75; stroke: none;' />
 <rect x='537.09' y='20.71' width='182.91' height='104.47' style='stroke-width: 10.67; stroke: none;' />
 <rect x='542.57' y='34.66' width='28.35' height='28.35' style='stroke-width: 10.67; stroke: none;' />
@@ -78,6 +78,6 @@
 <text x='579.38' y='54.68' style='font-size: 17.00px; font-family: sans;' textLength='111.51px' lengthAdjust='spacingAndGlyphs'>% Contribution</text>
 <text x='579.38' y='83.03' style='font-size: 17.00px; font-family: sans;' textLength='135.14px' lengthAdjust='spacingAndGlyphs'>% Study Variation</text>
 <text x='579.38' y='111.37' style='font-size: 17.00px; font-family: sans;' textLength='95.44px' lengthAdjust='spacingAndGlyphs'>% Tolerance</text>
-<text x='301.59' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='226.79px' lengthAdjust='spacingAndGlyphs'>components-of-variation-Wide</text>
+<text x='300.07' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='226.79px' lengthAdjust='spacingAndGlyphs'>components-of-variation-Wide</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/msaGaugeRR/components-of-variation-widetype3.svg
+++ b/tests/testthat/_snaps/msaGaugeRR/components-of-variation-widetype3.svg
@@ -18,50 +18,50 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+<rect x='-0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 </g>
 <defs>
-  <clipPath id='cpNzcuMDZ8NTI2LjEzfDIwLjcxfDUwNy4wOQ=='>
-    <rect x='77.06' y='20.71' width='449.07' height='486.39' />
+  <clipPath id='cpNzQuMDJ8NTI2LjEzfDIwLjcxfDUxMC4xNA=='>
+    <rect x='74.02' y='20.71' width='452.11' height='489.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNzcuMDZ8NTI2LjEzfDIwLjcxfDUwNy4wOQ==)'>
-<rect x='77.06' y='20.71' width='449.07' height='486.39' style='stroke-width: 10.67; stroke: none;' />
-<rect x='98.11' y='464.97' width='42.10' height='20.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='238.45' y='464.97' width='42.10' height='20.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='378.78' y='62.83' width='42.10' height='422.16' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='140.21' y='390.92' width='42.10' height='94.07' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='280.55' y='390.92' width='42.10' height='94.07' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='420.88' y='52.94' width='42.10' height='432.05' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='182.31' y='392.02' width='42.10' height='92.97' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<rect x='322.64' y='392.02' width='42.10' height='92.97' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<rect x='462.98' y='57.98' width='42.10' height='427.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<line x1='160.94' y1='507.09' x2='442.25' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='77.06' y1='485.30' x2='77.06' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<rect x='77.06' y='20.71' width='449.07' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+<g clip-path='url(#cpNzQuMDJ8NTI2LjEzfDIwLjcxfDUxMC4xNA==)'>
+<rect x='74.02' y='20.71' width='452.11' height='489.43' style='stroke-width: 10.67; stroke: none;' />
+<rect x='95.21' y='467.76' width='42.39' height='20.14' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='236.49' y='467.76' width='42.39' height='20.14' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='377.78' y='63.09' width='42.39' height='424.80' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='137.59' y='393.24' width='42.39' height='94.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='278.88' y='393.24' width='42.39' height='94.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='420.16' y='53.14' width='42.39' height='434.75' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='179.98' y='394.34' width='42.39' height='93.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<rect x='321.26' y='394.34' width='42.39' height='93.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<rect x='462.55' y='58.21' width='42.39' height='429.68' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<line x1='158.47' y1='510.14' x2='441.68' y2='510.14' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='74.02' y1='488.21' x2='74.02' y2='42.64' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='74.02' y='20.71' width='452.11' height='489.43' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='77.06,507.09 77.06,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<text x='61.58' y='490.84' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='61.58' y='402.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='61.58' y='313.97' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>40</text>
-<text x='61.58' y='225.53' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>60</text>
-<text x='61.58' y='137.10' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>80</text>
-<text x='61.58' y='48.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>100</text>
-<polyline points='68.56,484.99 77.06,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,396.55 77.06,396.55 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,308.12 77.06,308.12 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,219.68 77.06,219.68 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,131.25 77.06,131.25 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,42.82 77.06,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='77.06,507.09 526.13,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<polyline points='161.26,515.60 161.26,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='301.59,515.60 301.59,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='441.93,515.60 441.93,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<text x='161.26' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='85.06px' lengthAdjust='spacingAndGlyphs'>Gauge r&amp;R</text>
-<text x='301.59' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='54.82px' lengthAdjust='spacingAndGlyphs'>Repeat</text>
-<text x='441.93' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='87.86px' lengthAdjust='spacingAndGlyphs'>Part-to-Part</text>
-<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='70.32px' lengthAdjust='spacingAndGlyphs'>Percent</text>
+<polyline points='74.02,510.14 74.02,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='58.54' y='493.74' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='58.54' y='404.75' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='58.54' y='315.77' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='58.54' y='226.78' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='58.54' y='137.79' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='58.54' y='48.80' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>100</text>
+<polyline points='65.51,487.89 74.02,487.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,398.91 74.02,398.91 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,309.92 74.02,309.92 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,220.93 74.02,220.93 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,131.94 74.02,131.94 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,42.95 74.02,42.95 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='74.02,510.14 526.13,510.14 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='158.79,518.64 158.79,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='300.07,518.64 300.07,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='441.36,518.64 441.36,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='158.79' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='85.06px' lengthAdjust='spacingAndGlyphs'>Gauge r&amp;R</text>
+<text x='300.07' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='54.82px' lengthAdjust='spacingAndGlyphs'>Repeat</text>
+<text x='441.36' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='87.86px' lengthAdjust='spacingAndGlyphs'>Part-to-Part</text>
+<text transform='translate(16.68,265.42) rotate(-90)' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='58.60px' lengthAdjust='spacingAndGlyphs'>Percent</text>
 <rect x='537.09' y='20.71' width='182.91' height='104.47' style='stroke-width: 0.75; stroke: none;' />
 <rect x='537.09' y='20.71' width='182.91' height='104.47' style='stroke-width: 10.67; stroke: none;' />
 <rect x='542.57' y='34.66' width='28.35' height='28.35' style='stroke-width: 10.67; stroke: none;' />
@@ -73,6 +73,6 @@
 <text x='579.38' y='54.68' style='font-size: 17.00px; font-family: sans;' textLength='111.51px' lengthAdjust='spacingAndGlyphs'>% Contribution</text>
 <text x='579.38' y='83.03' style='font-size: 17.00px; font-family: sans;' textLength='135.14px' lengthAdjust='spacingAndGlyphs'>% Study Variation</text>
 <text x='579.38' y='111.37' style='font-size: 17.00px; font-family: sans;' textLength='95.44px' lengthAdjust='spacingAndGlyphs'>% Tolerance</text>
-<text x='301.59' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='274.04px' lengthAdjust='spacingAndGlyphs'>components-of-variation-WideType3</text>
+<text x='300.07' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='274.04px' lengthAdjust='spacingAndGlyphs'>components-of-variation-WideType3</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/msaGaugeRR/components-of-variation.svg
+++ b/tests/testthat/_snaps/msaGaugeRR/components-of-variation.svg
@@ -18,59 +18,59 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+<rect x='-0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 </g>
 <defs>
-  <clipPath id='cpNzcuMDZ8NTI2LjEzfDIwLjcxfDUwNy4wOQ=='>
-    <rect x='77.06' y='20.71' width='449.07' height='486.39' />
+  <clipPath id='cpNzQuMDJ8NTI2LjEzfDIwLjcxfDUxMC4xNA=='>
+    <rect x='74.02' y='20.71' width='452.11' height='489.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNzcuMDZ8NTI2LjEzfDIwLjcxfDUwNy4wOQ==)'>
-<rect x='77.06' y='20.71' width='449.07' height='486.39' style='stroke-width: 10.67; stroke: none;' />
-<rect x='93.10' y='480.46' width='32.08' height='4.53' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='200.02' y='481.13' width='32.08' height='3.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='306.94' y='484.31' width='32.08' height='0.67' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='413.86' y='173.68' width='32.08' height='311.31' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='125.18' y='447.17' width='32.08' height='37.82' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='232.10' y='450.08' width='32.08' height='34.91' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='339.02' y='470.43' width='32.08' height='14.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='445.94' y='171.42' width='32.08' height='313.56' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
-<rect x='157.25' y='434.78' width='32.08' height='50.21' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<rect x='264.17' y='438.65' width='32.08' height='46.34' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<rect x='371.09' y='465.67' width='32.08' height='19.32' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<rect x='478.01' y='68.73' width='32.08' height='416.25' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
-<line x1='140.90' y1='507.09' x2='462.29' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='77.06' y1='485.30' x2='77.06' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<rect x='77.06' y='20.71' width='449.07' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+<g clip-path='url(#cpNzQuMDJ8NTI2LjEzfDIwLjcxfDUxMC4xNA==)'>
+<rect x='74.02' y='20.71' width='452.11' height='489.43' style='stroke-width: 10.67; stroke: none;' />
+<rect x='90.16' y='483.34' width='32.29' height='4.56' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='197.81' y='484.01' width='32.29' height='3.88' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='305.45' y='487.22' width='32.29' height='0.67' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='413.10' y='174.64' width='32.29' height='313.26' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='122.46' y='449.84' width='32.29' height='38.06' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='230.10' y='452.77' width='32.29' height='35.13' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='337.75' y='473.25' width='32.29' height='14.64' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='445.39' y='172.37' width='32.29' height='315.53' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BA38;' />
+<rect x='154.75' y='437.37' width='32.29' height='50.52' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<rect x='262.40' y='441.26' width='32.29' height='46.63' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<rect x='370.04' y='468.45' width='32.29' height='19.44' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<rect x='477.69' y='69.03' width='32.29' height='418.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #619CFF;' />
+<line x1='138.28' y1='510.14' x2='461.86' y2='510.14' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='74.02' y1='488.21' x2='74.02' y2='42.64' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='74.02' y='20.71' width='452.11' height='489.43' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='77.06,507.09 77.06,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<text x='61.58' y='490.84' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='61.58' y='427.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='61.58' y='364.50' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>40</text>
-<text x='61.58' y='301.33' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>60</text>
-<text x='61.58' y='238.17' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>80</text>
-<text x='61.58' y='175.00' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='61.58' y='111.83' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>120</text>
-<text x='61.58' y='48.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>140</text>
-<polyline points='68.56,484.99 77.06,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,421.82 77.06,421.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,358.65 77.06,358.65 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,295.48 77.06,295.48 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,232.32 77.06,232.32 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,169.15 77.06,169.15 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,105.98 77.06,105.98 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,42.82 77.06,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='77.06,507.09 526.13,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<polyline points='141.21,515.60 141.21,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='248.13,515.60 248.13,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='355.06,515.60 355.06,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='461.98,515.60 461.98,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<text x='141.21' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='85.06px' lengthAdjust='spacingAndGlyphs'>Gauge r&amp;R</text>
-<text x='248.13' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='54.82px' lengthAdjust='spacingAndGlyphs'>Repeat</text>
-<text x='355.06' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='55.76px' lengthAdjust='spacingAndGlyphs'>Reprod</text>
-<text x='461.98' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='87.86px' lengthAdjust='spacingAndGlyphs'>Part-to-Part</text>
-<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='70.32px' lengthAdjust='spacingAndGlyphs'>Percent</text>
+<polyline points='74.02,510.14 74.02,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='58.54' y='493.74' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='58.54' y='430.18' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='58.54' y='366.62' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='58.54' y='303.05' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='58.54' y='239.49' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='58.54' y='175.93' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='58.54' y='112.37' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>120</text>
+<text x='58.54' y='48.80' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>140</text>
+<polyline points='65.51,487.89 74.02,487.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,424.33 74.02,424.33 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,360.77 74.02,360.77 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,297.21 74.02,297.21 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,233.64 74.02,233.64 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,170.08 74.02,170.08 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,106.52 74.02,106.52 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,42.95 74.02,42.95 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='74.02,510.14 526.13,510.14 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='138.60,518.64 138.60,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='246.25,518.64 246.25,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='353.89,518.64 353.89,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='461.54,518.64 461.54,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='138.60' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='85.06px' lengthAdjust='spacingAndGlyphs'>Gauge r&amp;R</text>
+<text x='246.25' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='54.82px' lengthAdjust='spacingAndGlyphs'>Repeat</text>
+<text x='353.89' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='55.76px' lengthAdjust='spacingAndGlyphs'>Reprod</text>
+<text x='461.54' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='87.86px' lengthAdjust='spacingAndGlyphs'>Part-to-Part</text>
+<text transform='translate(16.68,265.42) rotate(-90)' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='58.60px' lengthAdjust='spacingAndGlyphs'>Percent</text>
 <rect x='537.09' y='20.71' width='182.91' height='104.47' style='stroke-width: 0.75; stroke: none;' />
 <rect x='537.09' y='20.71' width='182.91' height='104.47' style='stroke-width: 10.67; stroke: none;' />
 <rect x='542.57' y='34.66' width='28.35' height='28.35' style='stroke-width: 10.67; stroke: none;' />
@@ -82,6 +82,6 @@
 <text x='579.38' y='54.68' style='font-size: 17.00px; font-family: sans;' textLength='111.51px' lengthAdjust='spacingAndGlyphs'>% Contribution</text>
 <text x='579.38' y='83.03' style='font-size: 17.00px; font-family: sans;' textLength='135.14px' lengthAdjust='spacingAndGlyphs'>% Study Variation</text>
 <text x='579.38' y='111.37' style='font-size: 17.00px; font-family: sans;' textLength='95.44px' lengthAdjust='spacingAndGlyphs'>% Tolerance</text>
-<text x='301.59' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='182.40px' lengthAdjust='spacingAndGlyphs'>components-of-variation</text>
+<text x='300.07' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='182.40px' lengthAdjust='spacingAndGlyphs'>components-of-variation</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/msaGaugeRRnonrep/components-of-variation.svg
+++ b/tests/testthat/_snaps/msaGaugeRRnonrep/components-of-variation.svg
@@ -18,51 +18,51 @@
   </clipPath>
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
+<rect x='-0.000000000000064' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 </g>
 <defs>
-  <clipPath id='cpNzcuMDZ8NTI2LjEzfDIwLjcxfDUwNy4wOQ=='>
-    <rect x='77.06' y='20.71' width='449.07' height='486.39' />
+  <clipPath id='cpNzQuMDJ8NTI2LjEzfDIwLjcxfDUxMC4xNA=='>
+    <rect x='74.02' y='20.71' width='452.11' height='489.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNzcuMDZ8NTI2LjEzfDIwLjcxfDUwNy4wOQ==)'>
-<rect x='77.06' y='20.71' width='449.07' height='486.39' style='stroke-width: 10.67; stroke: none;' />
-<rect x='93.10' y='462.79' width='48.11' height='22.19' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='200.02' y='462.79' width='48.11' height='22.19' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='306.94' y='484.99' width='48.11' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='413.86' y='65.01' width='48.11' height='419.98' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
-<rect x='141.21' y='385.93' width='48.11' height='99.06' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
-<rect x='248.13' y='385.93' width='48.11' height='99.06' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
-<rect x='355.06' y='484.99' width='48.11' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
-<rect x='461.98' y='54.06' width='48.11' height='430.93' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
-<line x1='140.90' y1='507.09' x2='462.29' y2='507.09' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='77.06' y1='485.30' x2='77.06' y2='42.50' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<rect x='77.06' y='20.71' width='449.07' height='486.39' style='stroke-width: 0.00; stroke: none;' />
+<g clip-path='url(#cpNzQuMDJ8NTI2LjEzfDIwLjcxfDUxMC4xNA==)'>
+<rect x='74.02' y='20.71' width='452.11' height='489.43' style='stroke-width: 10.67; stroke: none;' />
+<rect x='90.16' y='465.56' width='48.44' height='22.33' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='197.81' y='465.56' width='48.44' height='22.33' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='305.45' y='487.89' width='48.44' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='413.10' y='65.29' width='48.44' height='422.61' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #F8766D;' />
+<rect x='138.60' y='388.21' width='48.44' height='99.68' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='246.25' y='388.21' width='48.44' height='99.68' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='353.89' y='487.89' width='48.44' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<rect x='461.54' y='54.26' width='48.44' height='433.63' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
+<line x1='138.28' y1='510.14' x2='461.86' y2='510.14' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='74.02' y1='488.21' x2='74.02' y2='42.64' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='74.02' y='20.71' width='452.11' height='489.43' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='77.06,507.09 77.06,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<text x='61.58' y='490.84' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='61.58' y='402.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>20</text>
-<text x='61.58' y='313.97' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>40</text>
-<text x='61.58' y='225.53' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>60</text>
-<text x='61.58' y='137.10' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>80</text>
-<text x='61.58' y='48.67' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>100</text>
-<polyline points='68.56,484.99 77.06,484.99 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,396.55 77.06,396.55 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,308.12 77.06,308.12 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,219.68 77.06,219.68 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,131.25 77.06,131.25 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='68.56,42.82 77.06,42.82 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='77.06,507.09 526.13,507.09 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<polyline points='141.21,515.60 141.21,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='248.13,515.60 248.13,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='355.06,515.60 355.06,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<polyline points='461.98,515.60 461.98,507.09 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<text x='141.21' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='85.06px' lengthAdjust='spacingAndGlyphs'>Gauge r&amp;R</text>
-<text x='248.13' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='54.82px' lengthAdjust='spacingAndGlyphs'>Repeat</text>
-<text x='355.06' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='55.76px' lengthAdjust='spacingAndGlyphs'>Reprod</text>
-<text x='461.98' y='534.27' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='87.86px' lengthAdjust='spacingAndGlyphs'>Part-to-Part</text>
-<text transform='translate(19.02,263.90) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='70.32px' lengthAdjust='spacingAndGlyphs'>Percent</text>
+<polyline points='74.02,510.14 74.02,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='58.54' y='493.74' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='58.54' y='404.75' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>20</text>
+<text x='58.54' y='315.77' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>40</text>
+<text x='58.54' y='226.78' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>60</text>
+<text x='58.54' y='137.79' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>80</text>
+<text x='58.54' y='48.80' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='28.37px' lengthAdjust='spacingAndGlyphs'>100</text>
+<polyline points='65.51,487.89 74.02,487.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,398.91 74.02,398.91 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,309.92 74.02,309.92 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,220.93 74.02,220.93 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,131.94 74.02,131.94 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='65.51,42.95 74.02,42.95 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='74.02,510.14 526.13,510.14 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='138.60,518.64 138.60,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='246.25,518.64 246.25,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='353.89,518.64 353.89,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='461.54,518.64 461.54,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='138.60' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='85.06px' lengthAdjust='spacingAndGlyphs'>Gauge r&amp;R</text>
+<text x='246.25' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='54.82px' lengthAdjust='spacingAndGlyphs'>Repeat</text>
+<text x='353.89' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='55.76px' lengthAdjust='spacingAndGlyphs'>Reprod</text>
+<text x='461.54' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='87.86px' lengthAdjust='spacingAndGlyphs'>Part-to-Part</text>
+<text transform='translate(16.68,265.42) rotate(-90)' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='58.60px' lengthAdjust='spacingAndGlyphs'>Percent</text>
 <rect x='537.09' y='20.71' width='182.91' height='76.12' style='stroke-width: 0.75; stroke: none;' />
 <rect x='537.09' y='20.71' width='182.91' height='76.12' style='stroke-width: 10.67; stroke: none;' />
 <rect x='542.57' y='34.66' width='28.35' height='28.35' style='stroke-width: 10.67; stroke: none;' />
@@ -71,6 +71,6 @@
 <rect x='543.27' y='63.71' width='26.93' height='26.93' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #00BFC4;' />
 <text x='579.38' y='54.68' style='font-size: 17.00px; font-family: sans;' textLength='111.51px' lengthAdjust='spacingAndGlyphs'>% Contribution</text>
 <text x='579.38' y='83.03' style='font-size: 17.00px; font-family: sans;' textLength='135.14px' lengthAdjust='spacingAndGlyphs'>% Study Variation</text>
-<text x='301.59' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='182.40px' lengthAdjust='spacingAndGlyphs'>components-of-variation</text>
+<text x='300.07' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='182.40px' lengthAdjust='spacingAndGlyphs'>components-of-variation</text>
 </g>
 </svg>


### PR DESCRIPTION
- Fixes https://github.com/jasp-stats/jasp-issues/issues/2273: Fixed calculation of y-axis limits of variance component graph in gauge r&R. It sometimes did not include zero in the limits and then removed all bars.
- Updated unit tests as graphs changed slightly after using jasp_theme_raw and geom_rangeframe instead of theme_jasp in variance component graph.
- Fixes https://github.com/jasp-stats/jasp-issues/issues/2274: Fixed calculation of y-axis limits of percent process variation graph in gauge linearity. It sometimes did not include zero in the limits and then removed all bars.
- Updated unit tests as graphs changed slightly after using jasp_theme_raw and geom_rangeframe instead of theme_jasp in bias and linearty graph and percent process variation graph.
- Fixes https://github.com/jasp-stats/jasp-issues/issues/2286: Tried to compare different data types and only aligned them when numeric. Now always aligning data type.

Based on https://github.com/jasp-stats/jaspQualityControl/pull/279 to make the unit tests work.