### PR TITLE
Urgent DoE issues

### DIFF
--- a/R/doeAnalysis.R
+++ b/R/doeAnalysis.R
@@ -26,13 +26,13 @@ doeAnalysis <- function(jaspResults, dataset, options, ...) {
   }
   .doeAnalysisCheckErrors(dataset, options, ready)
 
-  # p <- try({
+  p <- try({
      .doeAnalysisMakeState(jaspResults, dataset, options, ready)
-  # })
-#
-#   if (isTryError(p)) {
-#     jaspResults$setError(gettextf("The analysis crashed with the following error message: %1$s", .extractErrorMessage(p)))
-#   }
+  })
+
+  if (isTryError(p)) {
+    jaspResults$setError(gettextf("The analysis crashed with the following error message: %1$s", .extractErrorMessage(p)))
+  }
 
   .doeAnalysisSummaryTable(jaspResults, options, ready)
   .doeAnalysisAnovaTable(jaspResults, options, ready)

--- a/inst/qml/doeAnalysis.qml
+++ b/inst/qml/doeAnalysis.qml
@@ -47,7 +47,7 @@ Form
 		{
 			id:									continuousFactors
 			name:                               "continuousFactors"
-			allowedColumns:                     ["scale"]
+			allowedColumns:                     ["scale", "ordinal"]
 			label:                              qsTr("Continuous Factors")
 			height:								125 * preferencesModel.uiScale
 		}
@@ -58,6 +58,7 @@ Form
 			singleVariable:                     true
 			label:                              qsTr("Blocks")
 			allowedColumns:                     ["ordinal", "scale", "nominal", "nominalText"]
+			visible:							false
 		}
 
 		AssignedVariablesList
@@ -139,7 +140,7 @@ Form
 			name:                                   "rsmPredefinedModel"
 			label:                              	qsTr("Select predefined model")
 			visible:								designType.currentValue == "responseSurfaceDesign"
-			checked: 								designType.currentValue == "responseSurfaceDesign"								
+			checked: 								designType.currentValue == "responseSurfaceDesign"
 
 			DropDown
 					{
@@ -158,7 +159,7 @@ Form
 
 		VariablesForm
 		{
-			enabled: !highestOrder.checked & !rsmPredefinedModel.checked
+			enabled: !highestOrder.checked & designType.currentValue == "factorialDesign"
 			preferredHeight: jaspTheme.smallDefaultVariablesFormHeight
 			AvailableVariablesList { name: "components"; title: qsTr("Components"); source: ["fixedFactors", "continuousFactors"]}
 			AssignedVariablesList {  name: "modelTerms"; id: modelTerms; title: qsTr("Model Terms"); listViewType: JASP.Interaction}


### PR DESCRIPTION
- Fixed issue that sometimes broke the RSM analysis. The rsm package calculated some "canonicals" that were not used in the JASP output. Setting the threshold to calcuate these to 0 resolved the issue.
- Removed option to specify blocks again, breaks too often.
- Removed options to specify manual terms for RSM analysis, breaks often and is not really useful without possibility of adding squared terms.