### PR TITLE
replaced gettext(%) by gettextf(%%)

### DIFF
--- a/R/msaGaugeRR.R
+++ b/R/msaGaugeRR.R
@@ -236,7 +236,7 @@ msaGaugeRR <- function(jaspResults, dataset, options, ...) {
   RRtable2$addColumnInfo(name = "source", title = gettext("Source"), type = "string")
   RRtable2$addColumnInfo(name = "SD", title = gettext("Std. Deviation"), type = "number")
   RRtable2$addColumnInfo(name = "studyVar", title = gettextf("Study Variation"), type = "number")
-  RRtable2$addColumnInfo(name = "percentStudyVar", title = gettext("% Study Variation"), type = "integer")
+  RRtable2$addColumnInfo(name = "percentStudyVar", title = gettextf("%% Study Variation"), type = "integer")
   if(options[["tolerance"]])
     RRtable2$addColumnInfo(name = "percentTolerance", title = gettextf("%% Tolerance"), type = "integer")
 


### PR DESCRIPTION
we should using `gettextf(%%)` while output single `%` in translation. otherwise any combination of characters after `%` will be considered a placeholder, then strings unable to match this placeholder in other language translations.

po file is ok but just this line. should run generate-translation action manually once.

cc @JTPetter 