### PR TITLE
Fixing axis labelling issues

### DIFF
--- a/R/doeAnalysis.R
+++ b/R/doeAnalysis.R
@@ -1769,7 +1769,7 @@ get_levels <- function(var, num_levels, dataset) {
       return()
     }
     result <- jaspResults[[dep]][["doeResult"]]$object[["regression"]]
-    plot$plotObject <- jaspGraphs::jaspHistogram(resid(result[["object"]]), "Residuals", binWidthType = options[["histogramBinWidthType"]],
+    plot$plotObject <- jaspGraphs::jaspHistogram(resid(result[["object"]]), gettext("Residuals"), binWidthType = options[["histogramBinWidthType"]],
                                                  numberOfBins = options[["histogramManualNumberOfBins"]])
   }
 }

--- a/R/doeAnalysis.R
+++ b/R/doeAnalysis.R
@@ -1856,7 +1856,7 @@ get_levels <- function(var, num_levels, dataset) {
     plotMat <- matrix(list(), 2, 2)
     plotMat[[1, 1]] <- .doeAnalysisPlotResidualsVsOrderPlotObject(result, dataset, options)
     plotMat[[2, 1]] <- .doeAnalysisPlotFittedVsResidualsPlotObject(result, options)
-    plotMat[[1, 2]] <- jaspGraphs::jaspHistogram(resid(result[["object"]]), "Residuals", binWidthType = options[["histogramBinWidthType"]],
+    plotMat[[1, 2]] <- jaspGraphs::jaspHistogram(resid(result[["object"]]), gettext("Residuals"), binWidthType = options[["histogramBinWidthType"]],
                                                  numberOfBins = options[["histogramManualNumberOfBins"]])
     plotMat[[2, 2]] <- jaspGraphs::plotQQnorm(resid(result[["object"]]), abline = TRUE) +
       ggplot2::scale_x_continuous(expand = ggplot2::expansion(mult = 0.1), name = gettext("Theoretical quantiles")) +

--- a/R/doeAnalysis.R
+++ b/R/doeAnalysis.R
@@ -1769,8 +1769,8 @@ get_levels <- function(var, num_levels, dataset) {
       return()
     }
     result <- jaspResults[[dep]][["doeResult"]]$object[["regression"]]
-    plot$plotObject <- jaspDescriptives::.plotMarginal(resid(result[["object"]]), NULL, binWidthType = options[["histogramBinWidthType"]],
-                                                       numberOfBins = options[["histogramManualNumberOfBins"]])
+    plot$plotObject <- jaspGraphs::jaspHistogram(resid(result[["object"]]), "Residuals", binWidthType = options[["histogramBinWidthType"]],
+                                                 numberOfBins = options[["histogramManualNumberOfBins"]])
   }
 }
 
@@ -1845,7 +1845,8 @@ get_levels <- function(var, num_levels, dataset) {
       return()
     }
     plot <- createJaspPlot(title = gettext("Matrix residual plot"), width = 1000, height = 1000)
-    plot$dependOn(options = c("fourInOneResidualPlot", .doeAnalysisBaseDependencies()))
+    plot$dependOn(options = c("histogramBinWidthType", "histogramManualNumberOfBins",
+                              "fourInOneResidualPlot", .doeAnalysisBaseDependencies()))
     plot$position <- 11
     jaspResults[[dep]][["fourInOneResidualPlot"]] <- plot
     if (!ready || is.null(jaspResults[[dep]][["doeResult"]]) || jaspResults[[dep]]$getError()) {
@@ -1855,7 +1856,8 @@ get_levels <- function(var, num_levels, dataset) {
     plotMat <- matrix(list(), 2, 2)
     plotMat[[1, 1]] <- .doeAnalysisPlotResidualsVsOrderPlotObject(result, dataset, options)
     plotMat[[2, 1]] <- .doeAnalysisPlotFittedVsResidualsPlotObject(result, options)
-    plotMat[[1, 2]] <- jaspDescriptives::.plotMarginal(resid(result[["object"]]), NULL)
+    plotMat[[1, 2]] <- jaspGraphs::jaspHistogram(resid(result[["object"]]), "Residuals", binWidthType = options[["histogramBinWidthType"]],
+                                                 numberOfBins = options[["histogramManualNumberOfBins"]])
     plotMat[[2, 2]] <- jaspGraphs::plotQQnorm(resid(result[["object"]]), abline = TRUE) +
       ggplot2::scale_x_continuous(expand = ggplot2::expansion(mult = 0.1), name = gettext("Theoretical quantiles")) +
       ggplot2::scale_y_continuous(expand = ggplot2::expansion(mult = 0.1), name = gettext("Observed quantiles"))

--- a/tests/testthat/_snaps/doeAnalysis/histogram-of-residuals27.svg
+++ b/tests/testthat/_snaps/doeAnalysis/histogram-of-residuals27.svg
@@ -21,55 +21,55 @@
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 </g>
 <defs>
-  <clipPath id='cpNTguMTV8NzIwLjAwfDIwLjcxfDU0NS4yOQ=='>
-    <rect x='58.15' y='20.71' width='661.85' height='524.59' />
+  <clipPath id='cpNTUuMTF8NzIwLjAwfDIwLjcxfDUxMC4xNA=='>
+    <rect x='55.11' y='20.71' width='664.89' height='489.43' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNTguMTV8NzIwLjAwfDIwLjcxfDU0NS4yOQ==)'>
-<rect x='58.15' y='20.71' width='661.85' height='524.59' style='stroke-width: 10.67; stroke: none;' />
-<polyline points='88.24,521.45 689.92,44.55 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<rect x='112.30' y='461.84' width='48.13' height='59.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='160.44' y='521.45' width='48.13' height='0.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='208.57' y='461.84' width='48.13' height='59.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='256.71' y='521.45' width='48.13' height='0.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='304.84' y='342.61' width='48.13' height='178.84' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='352.97' y='44.55' width='48.13' height='476.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='401.11' y='402.22' width='48.13' height='119.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='449.24' y='163.78' width='48.13' height='357.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='497.38' y='223.39' width='48.13' height='298.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='545.51' y='461.84' width='48.13' height='59.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='593.65' y='283.00' width='48.13' height='238.45' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='641.78' y='461.84' width='48.13' height='59.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<line x1='87.92' y1='545.29' x2='690.23' y2='545.29' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='58.15' y1='521.77' x2='58.15' y2='44.23' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<rect x='58.15' y='20.71' width='661.85' height='524.59' style='stroke-width: 0.00; stroke: none;' />
+<g clip-path='url(#cpNTUuMTF8NzIwLjAwfDIwLjcxfDUxMC4xNA==)'>
+<rect x='55.11' y='20.71' width='664.89' height='489.43' style='stroke-width: 10.67; stroke: none;' />
+<rect x='109.51' y='432.28' width='48.36' height='55.62' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='157.86' y='487.89' width='48.36' height='0.00' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='206.22' y='432.28' width='48.36' height='55.62' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='254.57' y='487.89' width='48.36' height='0.00' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='302.93' y='321.04' width='48.36' height='166.85' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='351.29' y='42.95' width='48.36' height='444.94' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='399.64' y='376.66' width='48.36' height='111.23' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='448.00' y='154.19' width='48.36' height='333.70' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='496.35' y='209.81' width='48.36' height='278.09' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='544.71' y='432.28' width='48.36' height='55.62' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='593.07' y='265.42' width='48.36' height='222.47' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='641.42' y='432.28' width='48.36' height='55.62' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<line x1='85.01' y1='510.14' x2='690.10' y2='510.14' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='55.11' y1='488.21' x2='55.11' y2='42.64' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='55.11' y='20.71' width='664.89' height='489.43' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='58.15,545.29 58.15,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<text x='42.67' y='527.30' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='42.67' y='408.07' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='42.67' y='288.85' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='42.67' y='169.63' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='42.67' y='50.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>8</text>
-<polyline points='49.65,521.45 58.15,521.45 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='49.65,402.22 58.15,402.22 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='49.65,283.00 58.15,283.00 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='49.65,163.78 58.15,163.78 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='49.65,44.55 58.15,44.55 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='58.15,545.29 720.00,545.29 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<polyline points='88.24,553.80 88.24,545.29 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='208.57,553.80 208.57,545.29 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='328.91,553.80 328.91,545.29 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='449.24,553.80 449.24,545.29 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='569.58,553.80 569.58,545.29 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='689.92,553.80 689.92,545.29 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<text x='88.24' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='24.57px' lengthAdjust='spacingAndGlyphs'>-15</text>
-<text x='208.57' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='24.57px' lengthAdjust='spacingAndGlyphs'>-10</text>
-<text x='328.91' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-5</text>
-<text x='449.24' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='569.58' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>5</text>
-<text x='689.92' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text transform='translate(19.02,283.00) rotate(-90)' text-anchor='middle' style='font-size: 20.40px; font-family: sans;' textLength='64.65px' lengthAdjust='spacingAndGlyphs'>Counts</text>
-<text x='389.08' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='187.11px' lengthAdjust='spacingAndGlyphs'>histogram-of-residuals27</text>
+<polyline points='55.11,510.14 55.11,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='39.63' y='493.74' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='39.63' y='382.51' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='39.63' y='271.27' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='39.63' y='160.04' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='39.63' y='48.80' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>8</text>
+<polyline points='46.60,487.89 55.11,487.89 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='46.60,376.66 55.11,376.66 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='46.60,265.42 55.11,265.42 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='46.60,154.19 55.11,154.19 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='46.60,42.95 55.11,42.95 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='55.11,510.14 720.00,510.14 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='85.33,518.64 85.33,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='206.22,518.64 206.22,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='327.11,518.64 327.11,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='448.00,518.64 448.00,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='568.89,518.64 568.89,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='689.78,518.64 689.78,510.14 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='85.33' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='24.57px' lengthAdjust='spacingAndGlyphs'>-15</text>
+<text x='206.22' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='24.57px' lengthAdjust='spacingAndGlyphs'>-10</text>
+<text x='327.11' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-5</text>
+<text x='448.00' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='568.89' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='689.78' y='537.32' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='387.55' y='567.49' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='74.66px' lengthAdjust='spacingAndGlyphs'>Residuals</text>
+<text transform='translate(16.68,265.42) rotate(-90)' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='53.88px' lengthAdjust='spacingAndGlyphs'>Counts</text>
+<text x='387.55' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='187.11px' lengthAdjust='spacingAndGlyphs'>histogram-of-residuals27</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/doeAnalysis/matrix-residual-plot27-subplot-3.svg
+++ b/tests/testthat/_snaps/doeAnalysis/matrix-residual-plot27-subplot-3.svg
@@ -21,55 +21,55 @@
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 10.67; stroke: none;' />
 </g>
 <defs>
-  <clipPath id='cpNDguNjB8NzIwLjAwfDIwLjcxfDU0NS4yOQ=='>
-    <rect x='48.60' y='20.71' width='671.40' height='524.59' />
+  <clipPath id='cpNDguNjB8NzIwLjAwfDIwLjcxfDUyMS42Mw=='>
+    <rect x='48.60' y='20.71' width='671.40' height='500.92' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpNDguNjB8NzIwLjAwfDIwLjcxfDU0NS4yOQ==)'>
-<rect x='48.60' y='20.71' width='671.40' height='524.59' style='stroke-width: 10.67; stroke: none;' />
-<polyline points='79.12,521.45 689.48,44.55 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
-<rect x='103.53' y='461.84' width='48.83' height='59.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='152.36' y='521.45' width='48.83' height='0.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='201.19' y='461.84' width='48.83' height='59.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='250.02' y='521.45' width='48.83' height='0.00' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='298.85' y='342.61' width='48.83' height='178.84' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='347.68' y='44.55' width='48.83' height='476.90' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='396.51' y='402.22' width='48.83' height='119.22' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='445.34' y='163.78' width='48.83' height='357.67' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='494.17' y='223.39' width='48.83' height='298.06' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='542.99' y='461.84' width='48.83' height='59.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='591.82' y='283.00' width='48.83' height='238.45' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<rect x='640.65' y='461.84' width='48.83' height='59.61' style='stroke-width: 1.07; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
-<line x1='78.80' y1='545.29' x2='689.80' y2='545.29' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<line x1='48.60' y1='521.77' x2='48.60' y2='44.23' style='stroke-width: 0.64; stroke-linecap: butt;' />
-<rect x='48.60' y='20.71' width='671.40' height='524.59' style='stroke-width: 0.00; stroke: none;' />
+<g clip-path='url(#cpNDguNjB8NzIwLjAwfDIwLjcxfDUyMS42Mw==)'>
+<rect x='48.60' y='20.71' width='671.40' height='500.92' style='stroke-width: 10.67; stroke: none;' />
+<rect x='103.53' y='441.93' width='48.83' height='56.92' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='152.36' y='498.86' width='48.83' height='0.00' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='201.19' y='441.93' width='48.83' height='56.92' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='250.02' y='498.86' width='48.83' height='0.00' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='298.85' y='328.09' width='48.83' height='170.77' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='347.68' y='43.48' width='48.83' height='455.38' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='396.51' y='385.01' width='48.83' height='113.84' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='445.34' y='157.32' width='48.83' height='341.53' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='494.17' y='214.24' width='48.83' height='284.61' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='542.99' y='441.93' width='48.83' height='56.92' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='591.82' y='271.17' width='48.83' height='227.69' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<rect x='640.65' y='441.93' width='48.83' height='56.92' style='stroke-width: 1.49; stroke-linecap: butt; stroke-linejoin: miter; fill: #BEBEBE;' />
+<line x1='78.80' y1='521.63' x2='689.80' y2='521.63' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<line x1='48.60' y1='499.18' x2='48.60' y2='43.16' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<rect x='48.60' y='20.71' width='671.40' height='500.92' style='stroke-width: 0.00; stroke: none;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<polyline points='48.60,545.29 48.60,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<text x='33.12' y='527.30' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='33.12' y='408.07' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
-<text x='33.12' y='288.85' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>4</text>
-<text x='33.12' y='169.63' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>6</text>
-<text x='33.12' y='50.40' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>8</text>
-<polyline points='40.10,521.45 48.60,521.45 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='40.10,402.22 48.60,402.22 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='40.10,283.00 48.60,283.00 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='40.10,163.78 48.60,163.78 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='40.10,44.55 48.60,44.55 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='48.60,545.29 720.00,545.29 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
-<polyline points='79.12,553.80 79.12,545.29 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='201.19,553.80 201.19,545.29 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='323.26,553.80 323.26,545.29 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='445.34,553.80 445.34,545.29 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='567.41,553.80 567.41,545.29 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<polyline points='689.48,553.80 689.48,545.29 ' style='stroke-width: 1.49; stroke-linecap: butt;' />
-<text x='79.12' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='24.57px' lengthAdjust='spacingAndGlyphs'>-15</text>
-<text x='201.19' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='24.57px' lengthAdjust='spacingAndGlyphs'>-10</text>
-<text x='323.26' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-5</text>
-<text x='445.34' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='567.41' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>5</text>
-<text x='689.48' y='572.47' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text transform='translate(10.53,283.00) rotate(-90)' text-anchor='middle' style='font-size: 15.30px; font-family: sans;' textLength='48.49px' lengthAdjust='spacingAndGlyphs'>Counts</text>
+<polyline points='48.60,521.63 48.60,20.71 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<text x='33.12' y='504.71' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='33.12' y='390.86' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='33.12' y='277.02' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='33.12' y='163.17' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='33.12' y='49.33' text-anchor='end' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>8</text>
+<polyline points='40.10,498.86 48.60,498.86 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='40.10,385.01 48.60,385.01 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='40.10,271.17 48.60,271.17 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='40.10,157.32 48.60,157.32 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='40.10,43.48 48.60,43.48 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='48.60,521.63 720.00,521.63 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt;' />
+<polyline points='79.12,530.13 79.12,521.63 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='201.19,530.13 201.19,521.63 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='323.26,530.13 323.26,521.63 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='445.34,530.13 445.34,521.63 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='567.41,530.13 567.41,521.63 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<polyline points='689.48,530.13 689.48,521.63 ' style='stroke-width: 0.64; stroke-linecap: butt;' />
+<text x='79.12' y='548.80' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='24.57px' lengthAdjust='spacingAndGlyphs'>-15</text>
+<text x='201.19' y='548.80' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='24.57px' lengthAdjust='spacingAndGlyphs'>-10</text>
+<text x='323.26' y='548.80' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='15.12px' lengthAdjust='spacingAndGlyphs'>-5</text>
+<text x='445.34' y='548.80' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='567.41' y='548.80' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='9.46px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='689.48' y='548.80' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='18.91px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='384.30' y='572.82' text-anchor='middle' style='font-size: 15.30px; font-family: sans;' textLength='67.20px' lengthAdjust='spacingAndGlyphs'>Residuals</text>
+<text transform='translate(10.53,271.17) rotate(-90)' text-anchor='middle' style='font-size: 15.30px; font-family: sans;' textLength='48.49px' lengthAdjust='spacingAndGlyphs'>Counts</text>
 <text x='384.30' y='11.70' text-anchor='middle' style='font-size: 17.00px; font-family: sans;' textLength='239.07px' lengthAdjust='spacingAndGlyphs'>matrix-residual-plot27-subplot-3</text>
 </g>
 </svg>


### PR DESCRIPTION
There were some problems with the x-axis labels for the histogram of the residuals in DOE.

This is fixed by:
- Using jaspGraphs::jaspHistogram
- Updating snapshots accordingly
- Additionally, the binwidth method now carries over to the matrix plot.