### PR TITLE
respect marginality in response surface stepwise selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,8 @@
 
 # jaspQualityControl (development version)
 
-
+## Fixed
+* Stepwise model selection in the Response Surface design now respects marginality: a squared term is no longer retained without its corresponding main effect.
 
 ---
 

--- a/R/doeAnalysis.R
+++ b/R/doeAnalysis.R
@@ -15,6 +15,24 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# Enforce marginality on a fitted model: a squared term I(x^2) requires its
+# main effect x. step() treats I(x^2) as unrelated to x (unlike interactions),
+# so stepwise selection may retain a squared term without its linear term.
+# Re-add any missing main effects, refit, and report which were forced in.
+.enforceSquaredTermMarginality <- function(model,
+                                           data = eval(stats::getCall(model)[["data"]], environment(stats::formula(model)))) {
+  modelTerms  <- attr(stats::terms(model), "term.labels")
+  squaredVars <- gsub("^I\\((.+)\\^2\\)$", "\\1", grep("^I\\(.+\\^2\\)$", modelTerms, value = TRUE))
+  forcedMainEffects <- setdiff(squaredVars, modelTerms)
+  if (length(forcedMainEffects) > 0) {
+    # update the formula (pure manipulation) and refit with explicit data, so the
+    # refit does not depend on the data object being in scope by name (as update() would).
+    newFormula <- stats::update(stats::formula(model), paste(". ~ . +", paste(forcedMainEffects, collapse = " + ")))
+    model      <- stats::lm(newFormula, data = data)
+  }
+  return(list(model = model, forcedMainEffects = forcedMainEffects))
+}
+
 .formatCoefEquation <- function(x, digits = .numDecimals) {
   vapply(x, function(val) {
     if (val == 0) return("0")
@@ -294,6 +312,12 @@ doeAnalysis <- function(jaspResults, dataset, options, ...) {
                                    aic = aic,
                                    coefficients = coef(model)))
 
+      # Enforce marginality before deriving the final model: step() may retain a
+      # squared term I(x^2) without its main effect x (see .enforceSquaredTermMarginality).
+      marginality       <- .enforceSquaredTermMarginality(stepwiseModel, stepwiseData)
+      stepwiseModel     <- marginality[["model"]]
+      forcedMainEffects <- marginality[["forcedMainEffects"]]
+
       excludedVars <- setdiff(names(fullModel$coefficients), names(stepwiseModel$coefficients))
       formula <- as.formula(stepwiseModel)
 
@@ -307,7 +331,8 @@ doeAnalysis <- function(jaspResults, dataset, options, ...) {
       )
 
       result[["stepwiseResult"]] <- list(excludedVars = gsub("I\\((.*)\\^2\\)", "\\1^2", excludedVars),
-                                         stepwiseResult = stepwiseResult)
+                                         stepwiseResult = stepwiseResult,
+                                         forcedMainEffects = forcedMainEffects)
     }
 
     regressionFit <- lm(formula, data = dataset)
@@ -1617,6 +1642,15 @@ get_levels <- function(var, num_levels, dataset) {
                                   "The following covariate was considered but not included: %s.",
                                   "The following covariates were considered but not included: %s."),
                          paste(excludedVars, collapse=", "))
+      tb$addFootnote(message)
+    }
+
+    forcedMainEffects <- result[["forcedMainEffects"]]
+    if (length(forcedMainEffects) > 0) {
+      message <- sprintf(ngettext(length(forcedMainEffects),
+                                  "The main effect %s was retained to respect marginality (its squared term is in the model).",
+                                  "The main effects %s were retained to respect marginality (their squared terms are in the model)."),
+                         paste(forcedMainEffects, collapse=", "))
       tb$addFootnote(message)
     }
 

--- a/R/doeAnalysis.R
+++ b/R/doeAnalysis.R
@@ -48,6 +48,23 @@
   }, character(1))
 }
 
+.enforceSquaredTermMarginality <- function(model, data = stats::model.frame(model)) {
+  modelTerms         <- attr(stats::terms(model), "term.labels")
+  squaredVars        <- gsub("^I\\((.+)\\^2\\)$", "\\1", grep("^I\\(.+\\^2\\)$", modelTerms, value = TRUE))
+  forcedMainEffects  <- setdiff(squaredVars, modelTerms)
+
+  if (length(forcedMainEffects) > 0) {
+    keep       <- model$keep
+    newFormula <- stats::update(stats::formula(model), paste(". ~ . +", paste(forcedMainEffects, collapse = " + ")))
+    model      <- stats::lm(newFormula, data = data)
+
+    if (!is.null(keep))
+      model$keep <- keep
+  }
+
+  list(model = model, forcedMainEffects = forcedMainEffects)
+}
+
 #' @export
 doeAnalysis <- function(jaspResults, dataset, options, ...) {
 
@@ -1639,8 +1656,8 @@ get_levels <- function(var, num_levels, dataset) {
     excludedVars <- result[["excludedVars"]]
     if (length(excludedVars) > 0) {
       message <- sprintf(ngettext(length(excludedVars),
-                                  "The following covariate was considered but not included: %s.",
-                                  "The following covariates were considered but not included: %s."),
+                                  "The following covariate was considered but not included: %1$s.",
+                                  "The following covariates were considered but not included: %1$s."),
                          paste(excludedVars, collapse=", "))
       tb$addFootnote(message)
     }
@@ -1648,8 +1665,8 @@ get_levels <- function(var, num_levels, dataset) {
     forcedMainEffects <- result[["forcedMainEffects"]]
     if (length(forcedMainEffects) > 0) {
       message <- sprintf(ngettext(length(forcedMainEffects),
-                                  "The main effect %s was retained to respect marginality (its squared term is in the model).",
-                                  "The main effects %s were retained to respect marginality (their squared terms are in the model)."),
+                                  "The main effect %1$s was retained to respect marginality (its squared term is in the model).",
+                                  "The main effects %1$s were retained to respect marginality (their squared terms are in the model)."),
                          paste(forcedMainEffects, collapse=", "))
       tb$addFootnote(message)
     }

--- a/tests/testthat/test-doeAnalysis.R
+++ b/tests/testthat/test-doeAnalysis.R
@@ -5157,5 +5157,37 @@ test_that("53.4 Response Optimizer Response Surface Change All Options - Respons
                                  list(100, 2, 12.3, 120.83, -22, 0.885700020509264))
 })
 
+## Stepwise marginality (response surface) ####
+
+test_that("Stepwise selection respects marginality: a squared term keeps its main effect", {
+  set.seed(1)
+  n <- 40
+  d <- data.frame(A = runif(n, -1, 1), B = runif(n, -1, 1))
+  d$y <- 2 * d$A^2 + 0.5 * d$B + rnorm(n, sd = 0.3) # A enters only via its square
+
+  model <- lm(y ~ I(A^2) + B + I(B^2), data = d)    # A^2 present, A absent
+  out   <- jaspQualityControl:::.enforceSquaredTermMarginality(model)
+  terms <- attr(stats::terms(out[["model"]]), "term.labels")
+
+  expect_equal(out[["forcedMainEffects"]], "A")
+  expect_true("A" %in% terms)
+  squaredVars <- gsub("^I\\((.+)\\^2\\)$", "\\1", grep("^I\\(.+\\^2\\)$", terms, value = TRUE))
+  expect_true(all(squaredVars %in% terms))
+})
+
+test_that("Stepwise marginality leaves a compliant model untouched", {
+  set.seed(1)
+  n <- 40
+  d <- data.frame(A = runif(n, -1, 1), B = runif(n, -1, 1))
+  d$y <- d$A + 2 * d$A^2 + rnorm(n, sd = 0.3)
+
+  model <- lm(y ~ A + I(A^2), data = d)             # already marginal
+  out   <- jaspQualityControl:::.enforceSquaredTermMarginality(model)
+
+  expect_length(out[["forcedMainEffects"]], 0)
+  expect_identical(coef(out[["model"]]), coef(model))
+})
+
+
 options("jaspRoundToPrecision" = NULL) # reset default
 

--- a/tests/testthat/test-doeAnalysis.R
+++ b/tests/testthat/test-doeAnalysis.R
@@ -5157,37 +5157,35 @@ test_that("53.4 Response Optimizer Response Surface Change All Options - Respons
                                  list(100, 2, 12.3, 120.83, -22, 0.885700020509264))
 })
 
-## Stepwise marginality (response surface) ####
-
-test_that("Stepwise selection respects marginality: a squared term keeps its main effect", {
+test_that("Stepwise marginality works without explicit data and preserves keep", {
   set.seed(1)
-  n <- 40
-  d <- data.frame(A = runif(n, -1, 1), B = runif(n, -1, 1))
-  d$y <- 2 * d$A^2 + 0.5 * d$B + rnorm(n, sd = 0.3) # A enters only via its square
+  model <- local({
+    A <- runif(40, -1, 1)
+    B <- runif(40, -1, 1)
+    y <- 2 * A^2 + 0.5 * B + rnorm(40, sd = 0.3)
 
-  model <- lm(y ~ I(A^2) + B + I(B^2), data = d)    # A^2 present, A absent
+    stats::lm(y ~ I(A^2) + B)
+  })
+  model$keep <- list(aic = 1)
+
   out   <- jaspQualityControl:::.enforceSquaredTermMarginality(model)
   terms <- attr(stats::terms(out[["model"]]), "term.labels")
 
   expect_equal(out[["forcedMainEffects"]], "A")
   expect_true("A" %in% terms)
-  squaredVars <- gsub("^I\\((.+)\\^2\\)$", "\\1", grep("^I\\(.+\\^2\\)$", terms, value = TRUE))
-  expect_true(all(squaredVars %in% terms))
+  expect_identical(out[["model"]][["keep"]], model[["keep"]])
 })
 
-test_that("Stepwise marginality leaves a compliant model untouched", {
+test_that("Stepwise marginality leaves compliant models untouched", {
   set.seed(1)
-  n <- 40
-  d <- data.frame(A = runif(n, -1, 1), B = runif(n, -1, 1))
-  d$y <- d$A + 2 * d$A^2 + rnorm(n, sd = 0.3)
+  d <- data.frame(A = runif(40, -1, 1))
+  d$y <- d$A + 2 * d$A^2 + rnorm(40, sd = 0.3)
 
-  model <- lm(y ~ A + I(A^2), data = d)             # already marginal
+  model <- stats::lm(y ~ A + I(A^2), data = d)
   out   <- jaspQualityControl:::.enforceSquaredTermMarginality(model)
 
   expect_length(out[["forcedMainEffects"]], 0)
-  expect_identical(coef(out[["model"]]), coef(model))
+  expect_identical(stats::coef(out[["model"]]), stats::coef(model))
 })
 
-
 options("jaspRoundToPrecision" = NULL) # reset default
-


### PR DESCRIPTION
step() treats I(x^2) as unrelated to x, so it could keep a squared term without its main effect. Re-add missing main effects and refit.
Fix https://github.com/jasp-stats/INTERNAL-jasp/issues/3265 
Fix https://github.com/jasp-stats/INTERNAL-jasp/issues/3218