### PR TITLE
[URGENT] Bug fix for DoE worksheet after replications being removed

### DIFF
--- a/R/doeFactorial.R
+++ b/R/doeFactorial.R
@@ -18,6 +18,11 @@
 #' @export
 doeFactorial <- function(jaspResults, dataset, options, ...) {
 
+  # 'repetitions' UI control is currently commented out in the QML; default to 0 so the
+  # summary table and design generation don't receive NULL (see doeFactorial.qml).
+  if (is.null(options[["repetitions"]]))
+    options[["repetitions"]] <- 0L
+
   selectedRow <- options[["selectedRow"]]
   maximumRow <- .getMaximumRow(options)
 


### PR DESCRIPTION
- a previous commit introduced a bug that breaks the preview table for all worksheets. It appears to be a GUI only bug, so the unit tests did not catch it.